### PR TITLE
[feat] 하단 네비게이션 컴포넌트 구현 및 라우팅 연결

### DIFF
--- a/src/components/common/BottomNavigation.tsx
+++ b/src/components/common/BottomNavigation.tsx
@@ -1,0 +1,51 @@
+import { BOTTOM_NAV_HEIGHT_CLASS, MOBILE_MAX_WIDTH } from '@/constants/layout';
+import { Calendar, Home, List } from 'lucide-react';
+
+import { Link } from 'react-router-dom';
+
+const navigationItems = [
+  {
+    label: '할일',
+    path: '/todos',
+    icon: List,
+  },
+  {
+    label: '홈',
+    path: '/',
+    icon: Home,
+  },
+  {
+    label: '규칙',
+    path: '/rules',
+    icon: Calendar,
+  },
+];
+
+const BottomNavigation = () => {
+  return (
+    <nav
+      className={`fixed bottom-4 left-1/2 z-10 -translate-x-1/2 ${MOBILE_MAX_WIDTH} `}
+    >
+      <div
+        className={`flex items-center justify-between rounded-[30px] bg-[#EEEEEE] px-6 ${BOTTOM_NAV_HEIGHT_CLASS}`}
+      >
+        {navigationItems.map((item) => {
+          const Icon = item.icon;
+
+          return (
+            <Link
+              key={item.path}
+              to={item.path}
+              className="flex w-20 flex-col items-center gap-1"
+            >
+              <Icon className="h-5 w-5" />
+              <span className="text-xs font-normal">{item.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};
+
+export default BottomNavigation;

--- a/src/components/common/BottomNavigation.tsx
+++ b/src/components/common/BottomNavigation.tsx
@@ -1,27 +1,18 @@
 import { BOTTOM_NAV_HEIGHT_CLASS, MOBILE_MAX_WIDTH } from '@/constants/layout';
 import { Calendar, Home, List } from 'lucide-react';
+import { Link, useLocation } from 'react-router-dom';
 
-import { Link } from 'react-router-dom';
+import { cn } from '@/lib/utils';
 
 const navigationItems = [
-  {
-    label: '할일',
-    path: '/todos',
-    icon: List,
-  },
-  {
-    label: '홈',
-    path: '/',
-    icon: Home,
-  },
-  {
-    label: '규칙',
-    path: '/rules',
-    icon: Calendar,
-  },
+  { label: '할 일', path: '/todos', icon: List },
+  { label: '홈', path: '/', icon: Home },
+  { label: '규칙', path: '/rules', icon: Calendar },
 ];
 
 const BottomNavigation = () => {
+  const location = useLocation();
+
   return (
     <nav
       className={`fixed bottom-4 left-1/2 z-10 -translate-x-1/2 ${MOBILE_MAX_WIDTH} `}
@@ -31,14 +22,20 @@ const BottomNavigation = () => {
       >
         {navigationItems.map((item) => {
           const Icon = item.icon;
+          const isActive = location.pathname === item.path;
 
           return (
             <Link
               key={item.path}
               to={item.path}
-              className="flex w-20 flex-col items-center gap-1"
+              className={cn(
+                'flex w-20 flex-col items-center gap-1',
+                isActive
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
             >
-              <Icon className="h-5 w-5" />
+              <Icon className={cn('h-5 w-5', isActive && 'scale-110')} />
               <span className="text-xs font-normal">{item.label}</span>
             </Link>
           );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import { HEADER_HEIGHT, MOBILE_MAX_WIDTH } from '@/constants/layout';
+import { HEADER_HEIGHT_CLASS, MOBILE_MAX_WIDTH } from '@/constants/layout';
 
 import Bell from '@/assets/bell.svg';
 import { Link } from 'react-router-dom';
@@ -11,7 +11,7 @@ const Header = () => {
       className={`fixed top-0 z-10 w-full ${MOBILE_MAX_WIDTH} backdrop-blur-xl`}
     >
       <div
-        className={`flex items-center justify-between ${HEADER_HEIGHT} px-4`}
+        className={`flex items-center justify-between ${HEADER_HEIGHT_CLASS} px-4`}
       >
         <h1 className="text-xl font-semibold">
           <Link to="/">Dzipsa</Link>

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,3 +1,8 @@
 // 임시
 export const MOBILE_MAX_WIDTH = 'max-w-[420px]';
-export const HEADER_HEIGHT = 'h-14';
+
+export const HEADER_HEIGHT = 56;
+export const HEADER_HEIGHT_CLASS = 'h-14';
+
+export const BOTTOM_NAV_HEIGHT = 64;
+export const BOTTOM_NAV_HEIGHT_CLASS = 'h-16';

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,13 +1,24 @@
+import { BOTTOM_NAV_HEIGHT, HEADER_HEIGHT } from '@/constants/layout';
+
+import BottomNavigation from '@/components/common/BottomNavigation';
 import Header from '@/components/common/Header';
 import { Outlet } from 'react-router-dom';
 
 const AppLayout = () => {
   return (
-    <div className="min-h-dvh">
+    <div>
       <Header />
 
-      <main className="relative min-h-dvh pt-14">
+      <main
+        className={`relative min-h-dvh`}
+        style={{
+          paddingBottom: BOTTOM_NAV_HEIGHT + 16,
+          paddingTop: HEADER_HEIGHT,
+        }}
+      >
         <Outlet />
+
+        <BottomNavigation />
       </main>
     </div>
   );

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -1,0 +1,5 @@
+const RulesPage = () => {
+  return <div>RulesPage</div>;
+};
+
+export default RulesPage;

--- a/src/pages/todos/TodosPage.tsx
+++ b/src/pages/todos/TodosPage.tsx
@@ -1,0 +1,5 @@
+const TodosPage = () => {
+  return <div>TodosPage</div>;
+};
+
+export default TodosPage;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -8,6 +8,8 @@ import MyPage from '@/pages/mypage/MyPage';
 import NotFoundPage from '@/pages/NotFoundPage';
 import NotificationPage from '@/pages/notification/NotificationPage';
 import RootLayout from '@/layouts/RootLayout';
+import RulesPage from '@/pages/rules/RulesPage';
+import TodosPage from '@/pages/todos/TodosPage';
 
 const Router = () => {
   return (
@@ -16,6 +18,8 @@ const Router = () => {
         {/* 헤더 포함 */}
         <Route element={<AppLayout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/todos" element={<TodosPage />} />
+          <Route path="/rules" element={<RulesPage />} />
         </Route>
 
         {/* 헤더 미포함 */}


### PR DESCRIPTION
## PR 개요
- 하단 네비게이션 컴포넌트 구현 및 할 일/규칙 페이지 라우팅 추가

## 변경 사항
### 1. 레이아웃 상수 추가 및 정리
- `layout.ts`에 레이아웃 관련 상수 추가
    - `HEADER_HEIGHT`, `HEADER_HEIGHT_CLASS`
    - `BOTTOM_NAV_HEIGHT`, `BOTTOM_NAV_HEIGHT_CLASS`
- `AppLayout`에서 상수를 사용해 `paddingTop`, `paddingBottom` 적용

### 2. 하단 네비게이션 컴포넌트 구현
- `layout.ts`에 레이아웃 관련 상수 추가
    - `HEADER_HEIGHT`, `HEADER_HEIGHT_CLASS`
    - `BOTTOM_NAV_HEIGHT`, `BOTTOM_NAV_HEIGHT_CLASS`
- `AppLayout`에서 상수를 사용해 `paddingTop`, `paddingBottom` 적용
- `BottomNavigation` `active` 상태 스타일 적용
    - `useLocation`으로 현재 경로 확인
    - `active` 탭 아이콘 확대 및 텍스트 색상 강조

### 3. 할 일/규칙 페이지 추가 및 라우팅 설정
- `TodosPage`, `RulesPage` 컴포넌트 생성
- `/todos`, `/rules` 라우트 추가

## 스크린샷 (선택)
| BottomNavigation | BottomNavigation |
|------------|------------|
| <img width="375" height="848" alt="Image" src="https://github.com/user-attachments/assets/8d57cca9-52cf-472b-a059-95967f0fe2e1" /> | ![BottomNavigation_1차](https://github.com/user-attachments/assets/c923a434-8d17-4b4c-aca8-cb943513aa08) |

## 추후 할 일
- [x] Todo 페이지 탭 구조 구현 (나의 할 일, 우리 집 할 일, 완료된 할 일)

## Related Issue
Closes #9 