### PR TITLE
[feat] 규칙 화면 UI 구현 - 와이어프레임(lo-fi) 반영

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -7,7 +7,12 @@ type EmptyStateProps = {
 
 const EmptyState = ({ message, className }: EmptyStateProps) => {
   return (
-    <p className={cn('text-muted-foreground px-1 text-sm', className)}>
+    <p
+      className={cn(
+        'text-muted-foreground py-6 text-center text-sm',
+        className
+      )}
+    >
       {message}
     </p>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,7 +5,11 @@ import { Link } from 'react-router-dom';
 import { PROFILE_IMAGE } from '@/mocks/mockData';
 import UserAvatar from '@/components/common/UserAvatar';
 
-const Header = () => {
+type HeaderProps = {
+  title: string;
+};
+
+const Header = ({ title }: HeaderProps) => {
   return (
     <header
       className={`fixed top-0 z-10 w-full ${MOBILE_MAX_WIDTH} backdrop-blur-xl`}
@@ -13,9 +17,7 @@ const Header = () => {
       <div
         className={`flex items-center justify-between ${HEADER_HEIGHT_CLASS} px-4`}
       >
-        <h1 className="text-xl font-semibold">
-          <Link to="/">Dzipsa</Link>
-        </h1>
+        <h1 className="text-xl font-semibold">{title}</h1>
 
         <div className="flex items-center gap-2">
           {/* 알림 */}

--- a/src/components/common/ListItemCard.tsx
+++ b/src/components/common/ListItemCard.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 type ListItemCardProps = {
   title: string;
   subtitle?: string;
+  left?: React.ReactNode;
   right?: React.ReactNode;
   onClick?: () => void;
   className?: string;
@@ -12,6 +13,7 @@ type ListItemCardProps = {
 const ListItemCard = ({
   title,
   subtitle,
+  left,
   right,
   onClick,
   className,
@@ -25,13 +27,20 @@ const ListItemCard = ({
       className
     )}
   >
-    <div className="min-w-0">
-      <p className="truncate text-base font-medium">{title}</p>
-      {subtitle && (
-        <p className="text-muted-foreground text-xs font-normal">{subtitle}</p>
-      )}
+    <div className="flex items-center gap-4">
+      {left && <div className="shrink-0">{left}</div>}
+
+      <div className="min-w-0">
+        <p className="truncate text-base font-medium">{title}</p>
+        {subtitle && (
+          <p className="text-muted-foreground text-xs font-normal">
+            {subtitle}
+          </p>
+        )}
+      </div>
     </div>
-    {right && <div className="shrink-0 pl-3">{right}</div>}
+
+    {right && <div className="shrink-0">{right}</div>}
   </Card>
 );
 

--- a/src/components/common/ListItemCard.tsx
+++ b/src/components/common/ListItemCard.tsx
@@ -23,14 +23,14 @@ const ListItemCard = ({
     tabIndex={onClick ? 0 : undefined}
     onClick={onClick}
     className={cn(
-      'flex items-center justify-between rounded-md border-[#D4D4D4] p-4',
+      'flex items-center rounded-md border-[#D4D4D4] p-4',
       className
     )}
   >
-    <div className="flex items-center gap-4">
+    <div className="flex min-w-0 flex-1 items-center gap-4">
       {left && <div className="shrink-0">{left}</div>}
 
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <p className="truncate text-base font-medium">{title}</p>
         {subtitle && (
           <p className="text-muted-foreground text-xs font-normal">
@@ -40,7 +40,7 @@ const ListItemCard = ({
       </div>
     </div>
 
-    {right && <div className="shrink-0">{right}</div>}
+    {right && <div className="shrink-0 pl-2">{right}</div>}
   </Card>
 );
 

--- a/src/components/common/ListSection.tsx
+++ b/src/components/common/ListSection.tsx
@@ -3,14 +3,25 @@ import { cn } from '@/lib/utils';
 type ListSectionProps = {
   title: string;
   children: React.ReactNode;
+  right?: React.ReactNode;
   className?: string;
 };
 
-const ListSection = ({ title, children, className }: ListSectionProps) => {
+const ListSection = ({
+  title,
+  children,
+  right,
+  className,
+}: ListSectionProps) => {
   return (
     <section className={cn('space-y-1 pt-2', className)}>
-      <h2 className="text-lg font-semibold">{title}</h2>
+      {/* 헤더 영역 */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {right && <div>{right}</div>}
+      </div>
 
+      {/* 리스트 영역 */}
       <div className="space-y-2">{children}</div>
     </section>
   );

--- a/src/components/common/RoundedBadge.tsx
+++ b/src/components/common/RoundedBadge.tsx
@@ -11,7 +11,7 @@ const RoundedBadge = ({ children, className }: RoundedBadgeProps) => {
     <Badge
       variant="outline"
       className={cn(
-        '!hover:bg-none rounded-full border-none px-[10px] py-[5px] shadow-none',
+        'rounded-full border-none px-[10px] py-[5px] shadow-none',
         className
       )}
     >

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,13 +1,21 @@
 import { BOTTOM_NAV_HEIGHT, HEADER_HEIGHT } from '@/constants/layout';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import BottomNavigation from '@/components/common/BottomNavigation';
 import Header from '@/components/common/Header';
-import { Outlet } from 'react-router-dom';
 
 const AppLayout = () => {
+  const { pathname } = useLocation();
+
+  const getHeaderTitle = () => {
+    if (pathname.startsWith('/todos')) return '할 일 홈';
+    if (pathname.startsWith('/rules')) return '규칙 홈';
+    return 'Dzipasa';
+  };
+
   return (
     <div>
-      <Header />
+      <Header title={getHeaderTitle()} />
 
       <main
         className={`relative min-h-dvh`}

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -1,4 +1,5 @@
 import type { Member } from '@/types/member';
+import type { Rule } from '@/types/rules';
 import type { Todo } from '@/types/todo';
 
 export const MOTTO = '깨끗하게 살자!';
@@ -356,4 +357,10 @@ export const mockTodoList: Todo[] = [
     completedAt: '2026-03-06T16:45:00',
     proofImageUrl: 'test',
   },
+];
+
+export const mockRulesList: Rule[] = [
+  { id: 1, title: '월요일은 다 먹는 날', disabled: true },
+  { id: 2, title: '3시 이후 샤워 금지', disabled: false },
+  { id: 3, title: '11시 이후 샤워 금지', disabled: false },
 ];

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -360,7 +360,14 @@ export const mockTodoList: Todo[] = [
 ];
 
 export const mockRulesList: Rule[] = [
-  { id: 1, title: '월요일은 다 먹는 날', disabled: true },
+  { id: 1, title: '월요일은 다 먹는 날', disabled: false },
   { id: 2, title: '3시 이후 샤워 금지', disabled: false },
   { id: 3, title: '11시 이후 샤워 금지', disabled: false },
+  { id: 4, title: '분리수거는 지정된 요일에만 하기', disabled: false },
+  { id: 5, title: '설거지는 사용 후 바로 하기', disabled: false },
+  { id: 6, title: '공용 냉장고 음식에는 이름 붙이기', disabled: false },
+  { id: 7, title: '밤 12시 이후 큰 소리 금지', disabled: false },
+  { id: 8, title: '욕실 사용 후 환풍기 10분 이상 켜두기', disabled: false },
+  { id: 9, title: '공용 물건은 제자리에 두기', disabled: false },
+  { id: 10, title: '외출 시 불, 가스 확인하기', disabled: false },
 ];

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -1,6 +1,8 @@
 import type { Member } from '@/types/member';
 import type { Todo } from '@/types/todo';
 
+export const MOTTO = '깨끗하게 살자!';
+
 export const MOCK_MY_ID = '1';
 export const MOCK_TODAY = '2026-03-06';
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,7 @@
 import {
   MOCK_MY_ID,
   MOCK_TODAY,
+  MOTTO,
   PROFILE_IMAGE,
   mockMembers,
   mockTodoList,
@@ -17,8 +18,6 @@ import UserAvatar from '@/components/common/UserAvatar';
 import { formatDueAt } from '@/utils/date';
 
 const HomePage = () => {
-  const motto = '깨끗하게 살자!';
-
   const myId = MOCK_MY_ID;
   const today = MOCK_TODAY;
 
@@ -32,7 +31,7 @@ const HomePage = () => {
 
   return (
     <div className="space-y-4 p-4">
-      <MottoSection motto={motto} />
+      <MottoSection motto={MOTTO} />
       <MembersSection members={mockMembers} />
       <DashboardSection missedCount={missedCount} />
       <ListSection title="오늘 할 일">

--- a/src/pages/rules/RuleCreatePage.tsx
+++ b/src/pages/rules/RuleCreatePage.tsx
@@ -1,0 +1,47 @@
+import { Check, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { HEADER_HEIGHT_CLASS } from '@/constants/layout';
+import { useNavigate } from 'react-router-dom';
+
+const RuleCreatePage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-dvh px-4">
+      <header
+        className={`flex items-center justify-between ${HEADER_HEIGHT_CLASS}`}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => navigate(-1)}
+          aria-label="닫기"
+          className="flex h-8 w-8"
+        >
+          <X className="h-5 w-5" />
+        </Button>
+
+        <h1 className="text-lg font-semibold">규칙 추가</h1>
+
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            console.log('완료');
+          }}
+          aria-label="완료"
+          className="flex h-8 w-8"
+        >
+          <Check className="h-5 w-5" />
+        </Button>
+      </header>
+
+      <div className="pt-4">
+        <div className="">규칙 추가 폼</div>
+      </div>
+    </div>
+  );
+};
+
+export default RuleCreatePage;

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -6,6 +6,7 @@ import { MOTTO } from '@/mocks/mockData';
 import MottoSection from '@/pages/home/components/MottoSection';
 import RoundedBadge from '@/components/common/RoundedBadge';
 import { cn } from '@/lib/utils';
+import { useNavigate } from 'react-router-dom';
 
 type RoundedButtonProps = {
   disabled?: boolean;
@@ -36,6 +37,8 @@ const RuleNotifyButton = ({ disabled = false }: RoundedButtonProps) => {
 };
 
 const RulesPage = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="space-y-4 p-4">
       <MottoSection motto={MOTTO} />
@@ -60,6 +63,7 @@ const RulesPage = () => {
         right={
           <Button
             variant="link"
+            onClick={() => navigate('/rules/new')}
             className="hover:bg-accent-foreground/5 active:bg-accent-foreground/10 h-fit px-2 py-1 hover:no-underline"
           >
             규칙 추가하기

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -1,25 +1,29 @@
+import { MOTTO, mockRulesList } from '@/mocks/mockData';
+
 import { AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ListItemCard from '@/components/common/ListItemCard';
 import ListSection from '@/components/common/ListSection';
-import { MOTTO } from '@/mocks/mockData';
 import MottoSection from '@/pages/home/components/MottoSection';
 import RoundedBadge from '@/components/common/RoundedBadge';
 import { cn } from '@/lib/utils';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 
 type RoundedButtonProps = {
   disabled?: boolean;
+  onClick?: () => void;
 };
 
-const RuleNotifyButton = ({ disabled = false }: RoundedButtonProps) => {
+const RuleNotifyButton = ({
+  disabled = false,
+  onClick,
+}: RoundedButtonProps) => {
   return (
     <button
       type="button"
       disabled={disabled}
-      onClick={() => {
-        console.log('클릭!');
-      }}
+      onClick={onClick}
       className="rounded-full disabled:cursor-default"
     >
       <RoundedBadge
@@ -38,24 +42,30 @@ const RuleNotifyButton = ({ disabled = false }: RoundedButtonProps) => {
 
 const RulesPage = () => {
   const navigate = useNavigate();
+  const [rules, setRules] = useState(mockRulesList);
+
+  const warningRules = rules.filter((rule) => rule.disabled);
+
+  const handleNotify = (ruleId: number) => {
+    setRules((prev) =>
+      prev.map((rule) =>
+        rule.id === ruleId ? { ...rule, disabled: true } : rule
+      )
+    );
+  };
 
   return (
     <div className="space-y-4 p-4">
       <MottoSection motto={MOTTO} />
 
       <ListSection title="최근 경고 요인">
-        <ListItemCard
-          title="월요일은 다 먹는 날"
-          left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
-        />
-        <ListItemCard
-          title="3시 이후 샤워 금지"
-          left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
-        />
-        <ListItemCard
-          title="11시 이후 샤워 금지"
-          left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
-        />
+        {warningRules.map((rule) => (
+          <ListItemCard
+            key={rule.id}
+            title={rule.title}
+            left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
+          />
+        ))}
       </ListSection>
 
       <ListSection
@@ -70,15 +80,18 @@ const RulesPage = () => {
           </Button>
         }
       >
-        <ListItemCard
-          title="월요일은 다 먹는 날"
-          right={<RuleNotifyButton disabled />}
-        />
-        <ListItemCard title="3시 이후 샤워 금지" right={<RuleNotifyButton />} />
-        <ListItemCard
-          title="11시 이후 샤워 금지"
-          right={<RuleNotifyButton />}
-        />
+        {rules.map((rule) => (
+          <ListItemCard
+            key={rule.id}
+            title={rule.title}
+            right={
+              <RuleNotifyButton
+                disabled={rule.disabled}
+                onClick={() => handleNotify(rule.id)}
+              />
+            }
+          />
+        ))}
       </ListSection>
     </div>
   );

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -1,5 +1,62 @@
+import ListItemCard from '@/components/common/ListItemCard';
+import ListSection from '@/components/common/ListSection';
+import { MOTTO } from '@/mocks/mockData';
+import MottoSection from '@/pages/home/components/MottoSection';
+import RoundedBadge from '@/components/common/RoundedBadge';
+import { cn } from '@/lib/utils';
+
+type RoundedButtonProps = {
+  disabled?: boolean;
+};
+
+const RuleNotifyButton = ({ disabled = false }: RoundedButtonProps) => {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => {
+        console.log('클릭!');
+      }}
+      className="rounded-full disabled:cursor-default"
+    >
+      <RoundedBadge
+        className={cn(
+          'text-white',
+          disabled
+            ? 'bg-[#D4D4D4]'
+            : 'bg-[#636363] hover:bg-slate-700 active:bg-slate-800'
+        )}
+      >
+        집사에게 알리기
+      </RoundedBadge>
+    </button>
+  );
+};
+
 const RulesPage = () => {
-  return <div>RulesPage</div>;
+  return (
+    <div className="space-y-4 p-4">
+      <MottoSection motto={MOTTO} />
+
+      <ListSection title="최근 경고 요인">
+        <ListItemCard title="월요일은 다 먹는 날" />
+        <ListItemCard title="3시 이후 샤워 금지" />
+        <ListItemCard title="11시 이후 샤워 금지" />
+      </ListSection>
+
+      <ListSection title="우리집 규칙 리스트">
+        <ListItemCard
+          title="월요일은 다 먹는 날"
+          right={<RuleNotifyButton disabled />}
+        />
+        <ListItemCard title="3시 이후 샤워 금지" right={<RuleNotifyButton />} />
+        <ListItemCard
+          title="11시 이후 샤워 금지"
+          right={<RuleNotifyButton />}
+        />
+      </ListSection>
+    </div>
+  );
 };
 
 export default RulesPage;

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -44,12 +44,17 @@ const RulesPage = () => {
   const navigate = useNavigate();
   const [rules, setRules] = useState(mockRulesList);
 
-  const warningRules = rules.filter((rule) => rule.disabled);
+  const warningRules = rules
+    .filter((rule) => rule.disabled && rule.warnedAt)
+    .sort((a, b) => (b.warnedAt ?? 0) - (a.warnedAt ?? 0))
+    .slice(0, 3);
 
   const handleNotify = (ruleId: number) => {
     setRules((prev) =>
       prev.map((rule) =>
-        rule.id === ruleId ? { ...rule, disabled: true } : rule
+        rule.id === ruleId
+          ? { ...rule, disabled: true, warnedAt: Date.now() }
+          : rule
       )
     );
   };
@@ -58,15 +63,17 @@ const RulesPage = () => {
     <div className="space-y-4 p-4">
       <MottoSection motto={MOTTO} />
 
-      <ListSection title="최근 경고 요인">
-        {warningRules.map((rule) => (
-          <ListItemCard
-            key={rule.id}
-            title={rule.title}
-            left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
-          />
-        ))}
-      </ListSection>
+      {warningRules.length > 0 && (
+        <ListSection title="최근 경고 요인">
+          {warningRules.map((rule) => (
+            <ListItemCard
+              key={rule.id}
+              title={rule.title}
+              left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
+            />
+          ))}
+        </ListSection>
+      )}
 
       <ListSection
         title="우리집 규칙 리스트"

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import ListItemCard from '@/components/common/ListItemCard';
 import ListSection from '@/components/common/ListSection';
 import { MOTTO } from '@/mocks/mockData';
@@ -54,7 +55,17 @@ const RulesPage = () => {
         />
       </ListSection>
 
-      <ListSection title="우리집 규칙 리스트">
+      <ListSection
+        title="우리집 규칙 리스트"
+        right={
+          <Button
+            variant="link"
+            className="hover:bg-accent-foreground/5 active:bg-accent-foreground/10 h-fit px-2 py-1 hover:no-underline"
+          >
+            규칙 추가하기
+          </Button>
+        }
+      >
         <ListItemCard
           title="월요일은 다 먹는 날"
           right={<RuleNotifyButton disabled />}

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from 'lucide-react';
 import ListItemCard from '@/components/common/ListItemCard';
 import ListSection from '@/components/common/ListSection';
 import { MOTTO } from '@/mocks/mockData';
@@ -39,9 +40,18 @@ const RulesPage = () => {
       <MottoSection motto={MOTTO} />
 
       <ListSection title="최근 경고 요인">
-        <ListItemCard title="월요일은 다 먹는 날" />
-        <ListItemCard title="3시 이후 샤워 금지" />
-        <ListItemCard title="11시 이후 샤워 금지" />
+        <ListItemCard
+          title="월요일은 다 먹는 날"
+          left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
+        />
+        <ListItemCard
+          title="3시 이후 샤워 금지"
+          left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
+        />
+        <ListItemCard
+          title="11시 이후 샤워 금지"
+          left={<AlertTriangle className="h-8 w-8 text-yellow-400" />}
+        />
       </ListSection>
 
       <ListSection title="우리집 규칙 리스트">

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -6,40 +6,9 @@ import EmptyState from '@/components/common/EmptyState';
 import ListItemCard from '@/components/common/ListItemCard';
 import ListSection from '@/components/common/ListSection';
 import MottoSection from '@/pages/home/components/MottoSection';
-import RoundedBadge from '@/components/common/RoundedBadge';
-import { cn } from '@/lib/utils';
+import RuleNotifyButton from '@/pages/rules/components/RuleNotifyButton';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
-
-type RoundedButtonProps = {
-  disabled?: boolean;
-  onClick?: () => void;
-};
-
-const RuleNotifyButton = ({
-  disabled = false,
-  onClick,
-}: RoundedButtonProps) => {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className="rounded-full disabled:cursor-default"
-    >
-      <RoundedBadge
-        className={cn(
-          'text-white',
-          disabled
-            ? 'bg-[#D4D4D4]'
-            : 'bg-[#636363] hover:bg-slate-700 active:bg-slate-800'
-        )}
-      >
-        집사에게 알리기
-      </RoundedBadge>
-    </button>
-  );
-};
 
 const RulesPage = () => {
   const navigate = useNavigate();

--- a/src/pages/rules/RulesPage.tsx
+++ b/src/pages/rules/RulesPage.tsx
@@ -2,6 +2,7 @@ import { MOTTO, mockRulesList } from '@/mocks/mockData';
 
 import { AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import EmptyState from '@/components/common/EmptyState';
 import ListItemCard from '@/components/common/ListItemCard';
 import ListSection from '@/components/common/ListSection';
 import MottoSection from '@/pages/home/components/MottoSection';
@@ -87,18 +88,22 @@ const RulesPage = () => {
           </Button>
         }
       >
-        {rules.map((rule) => (
-          <ListItemCard
-            key={rule.id}
-            title={rule.title}
-            right={
-              <RuleNotifyButton
-                disabled={rule.disabled}
-                onClick={() => handleNotify(rule.id)}
-              />
-            }
-          />
-        ))}
+        {rules.length === 0 ? (
+          <EmptyState message="등록된 규칙이 없어요. 규칙을 추가해주세요!" />
+        ) : (
+          rules.map((rule) => (
+            <ListItemCard
+              key={rule.id}
+              title={rule.title}
+              right={
+                <RuleNotifyButton
+                  disabled={rule.disabled}
+                  onClick={() => handleNotify(rule.id)}
+                />
+              }
+            />
+          ))
+        )}
       </ListSection>
     </div>
   );

--- a/src/pages/rules/components/RuleNotifyButton.tsx
+++ b/src/pages/rules/components/RuleNotifyButton.tsx
@@ -1,0 +1,34 @@
+import RoundedBadge from '@/components/common/RoundedBadge';
+import { cn } from '@/lib/utils';
+
+type RoundedButtonProps = {
+  disabled?: boolean;
+  onClick?: () => void;
+};
+
+const RuleNotifyButton = ({
+  disabled = false,
+  onClick,
+}: RoundedButtonProps) => {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded-full disabled:cursor-default"
+    >
+      <RoundedBadge
+        className={cn(
+          'text-white',
+          disabled
+            ? 'bg-[#D4D4D4]'
+            : 'bg-[#636363] hover:bg-slate-700 active:bg-slate-800'
+        )}
+      >
+        집사에게 알리기
+      </RoundedBadge>
+    </button>
+  );
+};
+
+export default RuleNotifyButton;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -8,6 +8,7 @@ import MyPage from '@/pages/mypage/MyPage';
 import NotFoundPage from '@/pages/NotFoundPage';
 import NotificationPage from '@/pages/notification/NotificationPage';
 import RootLayout from '@/layouts/RootLayout';
+import RuleCreatePage from '@/pages/rules/RuleCreatePage';
 import RulesPage from '@/pages/rules/RulesPage';
 import { TODO_TABS } from '@/constants/todos';
 import TodosPage from '@/pages/todos/TodosPage';
@@ -33,6 +34,8 @@ const Router = () => {
 
         <Route path="/notifications" element={<NotificationPage />} />
         <Route path="/mypage" element={<MyPage />} />
+
+        <Route path="/rules/new" element={<RuleCreatePage />} />
 
         {/* 404 페이지 */}
         <Route path="*" element={<NotFoundPage />} />

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -1,0 +1,5 @@
+export type Rule = {
+  id: number;
+  title: string;
+  disabled?: boolean;
+};

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -2,4 +2,5 @@ export type Rule = {
   id: number;
   title: string;
   disabled?: boolean;
+  warnedAt?: number;
 };


### PR DESCRIPTION
## PR 개요
- 와이프레임(lo-fi)을 기반으로 한 할 일 화면 UI 구현
- 규칙 리스트와 최근 경고 요인 섹션을 구성하고, “집사에게 알리기” 버튼 클릭 시 경고 요인에 반영되는 동작 구현
- 규칙 추가 페이지(`/rules/new`) 라우팅 및 기본 헤더 UI 추가

## 변경 사항
### 1. Header 및 공통 컴포넌트 개선
- `Header` title을 라우트 기반으로 분기 처리 및 기존 링크 제거
- `ListItemCard`에 `left` / `right` 슬롯 추가
- `ListItemCard` 제목 텍스트 overflow 시 말줄임(...) 처리
- `ListSection`에 `right` 슬롯 추가
- `RuleNotifyButton` 컴포넌트 분리
- html `lang` 속성을 `ko`로 변경

### 2. 규칙 홈 화면 UI 구현
- `MOTTO` mock 분리 및 적용
- 규칙 페이지 섹션 구성
    - 최근 경고 요인
    - 우리집 규칙 리스트
- 최근 경고 요인 카드에 경고 아이콘 적용
- 우리집 규칙 리스트 섹션에 `규칙 추가하기` 버튼 추가
- 규칙이 없을 경우 안내 문구 노출 (empty state 처리)

### 3. 규칙 상태 로직 구현
- `mockRulesList` 데이터 생성 및 확장
- 규칙 mock 데이터 기반 렌더링 적용
- 집사에게 알리기 버튼 클릭 시:
    - 해당 규칙 `disabled` 처리
    - 최근 경고 요인 섹션에 즉시 반영
- `warnedAt` 필드 추가
- 최근 경고 요인:
    - 최신순 정렬
    - 최근 3개만 노출
    - 데이터가 존재할 경우에만 섹션 렌더링

### 4. 규칙 추가 페이지
- `RuleCreatePage` 생성
- `/rules/new` 라우트 추가
- 상단 헤더 UI(닫기/완료 버튼) 구현

## 스크린샷 (선택)
### 🧩 RulesPage
| 와이어프레임 | 구현 화면 |
|------------|------------|
| <img width="375" height="800" alt="RulesPage" src="https://github.com/user-attachments/assets/8f6d3453-19eb-4993-97e4-8c6552cadb2b" /> | ![RulesPage_1차](https://github.com/user-attachments/assets/9d322860-ef10-4ffc-9b2f-5b051bcea315) |

## 추후 할 일
- [ ] 규칙 추가 폼 UI 구현

## Related Issue
Closes #13 
