### PR TITLE
[refactor] Room/Auth 도메인 서버 상태 관리 구조 개선 (TanStack Query 도입)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "axios": "^1.13.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-query':
+        specifier: ^5.90.21
+        version: 5.90.21(react@19.2.4)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.91.3
+        version: 5.91.3(@tanstack/react-query@5.90.21(react@19.2.4))(react@19.2.4)
       axios:
         specifier: ^1.13.6
         version: 1.13.6
@@ -1134,6 +1140,23 @@ packages:
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/query-devtools@5.93.0':
+    resolution: {integrity: sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==}
+
+  '@tanstack/react-query-devtools@5.91.3':
+    resolution: {integrity: sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.90.20
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.90.21':
+    resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2964,6 +2987,21 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/query-devtools@5.93.0': {}
+
+  '@tanstack/react-query-devtools@5.91.3(@tanstack/react-query@5.90.21(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-devtools': 5.93.0
+      '@tanstack/react-query': 5.90.21(react@19.2.4)
+      react: 19.2.4
+
+  '@tanstack/react-query@5.90.21(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.4
 
   '@types/estree@1.0.8': {}
 

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,4 +1,5 @@
-import { getMe, logout } from '@/api/auth/auth.api';
+import type { MeResponse } from '@/api/auth/auth.types';
+import { agreeToTerms, getMe, logout } from '@/api/auth/auth.api';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { queryClient } from '@/lib/queryClient';
@@ -21,6 +22,19 @@ export const useLogoutMutation = () => {
     mutationFn: logout,
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: queryKeys.auth.me });
+    },
+  });
+};
+
+export const useAgreeToTermsMutation = () => {
+  return useMutation({
+    mutationFn: agreeToTerms,
+    onSuccess: () => {
+      queryClient.setQueryData(
+        queryKeys.auth.me,
+        (prev: MeResponse | undefined) =>
+          prev ? { ...prev, termsAgreed: true } : prev
+      );
     },
   });
 };

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -22,7 +22,6 @@ export const useMeQuery = ({ enabled = true }: UseMeQueryParams = {}) => {
 };
 
 // Mutations
-
 // 약관 동의
 export const useAgreeToTermsMutation = () => {
   return useMutation({

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -2,9 +2,14 @@ import { getMe } from '@/api/auth/auth.api';
 import { queryKeys } from '@/lib/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
-export const useMeQuery = () => {
+type UseMeQueryParams = {
+  enabled?: boolean;
+};
+
+export const useMeQuery = ({ enabled = true }: UseMeQueryParams = {}) => {
   return useQuery({
     queryKey: queryKeys.auth.me,
     queryFn: getMe,
+    enabled,
   });
 };

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,6 +1,8 @@
-import { getMe } from '@/api/auth/auth.api';
+import { getMe, logout } from '@/api/auth/auth.api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
-import { useQuery } from '@tanstack/react-query';
 
 type UseMeQueryParams = {
   enabled?: boolean;
@@ -11,5 +13,14 @@ export const useMeQuery = ({ enabled = true }: UseMeQueryParams = {}) => {
     queryKey: queryKeys.auth.me,
     queryFn: getMe,
     enabled,
+  });
+};
+
+export const useLogoutMutation = () => {
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: queryKeys.auth.me });
+    },
   });
 };

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export const useMeQuery = () => {
   return useQuery({
-    queryKey: queryKeys.me,
+    queryKey: queryKeys.auth.me,
     queryFn: getMe,
   });
 };

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,0 +1,10 @@
+import { getMe } from '@/api/auth/auth.api';
+import { queryKeys } from '@/lib/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+export const useMeQuery = () => {
+  return useQuery({
+    queryKey: queryKeys.me,
+    queryFn: getMe,
+  });
+};

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,8 +1,8 @@
-import type { MeResponse } from '@/api/auth/auth.types';
 import { agreeToTerms, getMe, logout, updateMe } from '@/api/auth/auth.api';
-import type { UpdateMeRequest } from '@/api/auth/auth.types';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
+import type { MeResponse } from '@/api/auth/auth.types';
+import type { UpdateMeRequest } from '@/api/auth/auth.types';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
 
@@ -10,6 +10,8 @@ type UseMeQueryParams = {
   enabled?: boolean;
 };
 
+// Queries
+// 내 정보 조회
 export const useMeQuery = ({ enabled = true }: UseMeQueryParams = {}) => {
   return useQuery({
     queryKey: queryKeys.auth.me,
@@ -18,15 +20,9 @@ export const useMeQuery = ({ enabled = true }: UseMeQueryParams = {}) => {
   });
 };
 
-export const useLogoutMutation = () => {
-  return useMutation({
-    mutationFn: logout,
-    onSuccess: () => {
-      queryClient.removeQueries({ queryKey: queryKeys.auth.me });
-    },
-  });
-};
+// Mutations
 
+// 약관 동의
 export const useAgreeToTermsMutation = () => {
   return useMutation({
     mutationFn: agreeToTerms,
@@ -40,11 +36,22 @@ export const useAgreeToTermsMutation = () => {
   });
 };
 
+// 내 정보 수정
 export const useUpdateMeMutation = () => {
   return useMutation({
     mutationFn: (payload: UpdateMeRequest) => updateMe(payload),
     onSuccess: (updatedMe) => {
       queryClient.setQueryData(queryKeys.auth.me, updatedMe);
+    },
+  });
+};
+
+// 로그아웃
+export const useLogoutMutation = () => {
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: queryKeys.auth.me });
     },
   });
 };

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -17,6 +17,7 @@ export const useMeQuery = ({ enabled = true }: UseMeQueryParams = {}) => {
     queryKey: queryKeys.auth.me,
     queryFn: getMe,
     enabled,
+    staleTime: 1000 * 60 * 5,
   });
 };
 

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,5 +1,6 @@
 import type { MeResponse } from '@/api/auth/auth.types';
-import { agreeToTerms, getMe, logout } from '@/api/auth/auth.api';
+import { agreeToTerms, getMe, logout, updateMe } from '@/api/auth/auth.api';
+import type { UpdateMeRequest } from '@/api/auth/auth.types';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { queryClient } from '@/lib/queryClient';
@@ -35,6 +36,15 @@ export const useAgreeToTermsMutation = () => {
         (prev: MeResponse | undefined) =>
           prev ? { ...prev, termsAgreed: true } : prev
       );
+    },
+  });
+};
+
+export const useUpdateMeMutation = () => {
+  return useMutation({
+    mutationFn: (payload: UpdateMeRequest) => updateMe(payload),
+    onSuccess: (updatedMe) => {
+      queryClient.setQueryData(queryKeys.auth.me, updatedMe);
     },
   });
 };

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -1,4 +1,4 @@
-import type { MeResponse } from '@/api/auth/auth.types';
+import type { CreateRoomRequest, JoinRoomRequest } from '@/api/room/room.types';
 import {
   createRoom,
   getInvitationCode,
@@ -7,23 +7,14 @@ import {
   leaveRoom,
   reissueInvitationCode,
 } from '@/api/room/room.api';
-import type { CreateRoomRequest, JoinRoomRequest } from '@/api/room/room.types';
 import { useMutation, useQuery } from '@tanstack/react-query';
+
+import type { MeResponse } from '@/api/auth/auth.types';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
 
-export const useCreateRoomMutation = () => {
-  return useMutation({
-    mutationFn: (payload: CreateRoomRequest) => createRoom(payload),
-  });
-};
-
-export const useJoinRoomMutation = () => {
-  return useMutation({
-    mutationFn: (payload: JoinRoomRequest) => joinRoom(payload),
-  });
-};
-
+// Queries
+// 내 방 정보 조회
 export const useMyRoomQuery = () => {
   return useQuery({
     queryKey: queryKeys.room.myRoom,
@@ -31,6 +22,7 @@ export const useMyRoomQuery = () => {
   });
 };
 
+// 초대 코드 조회
 export const useInvitationCodeQuery = () => {
   return useQuery({
     queryKey: queryKeys.room.invitationCode,
@@ -38,6 +30,22 @@ export const useInvitationCodeQuery = () => {
   });
 };
 
+// Mutations
+// 방 생성
+export const useCreateRoomMutation = () => {
+  return useMutation({
+    mutationFn: (payload: CreateRoomRequest) => createRoom(payload),
+  });
+};
+
+// 방 입장
+export const useJoinRoomMutation = () => {
+  return useMutation({
+    mutationFn: (payload: JoinRoomRequest) => joinRoom(payload),
+  });
+};
+
+// 초대 코드 재발급
 export const useReissueInvitationCodeMutation = () => {
   return useMutation({
     mutationFn: reissueInvitationCode,
@@ -47,6 +55,7 @@ export const useReissueInvitationCodeMutation = () => {
   });
 };
 
+// 방 나가기
 export const useLeaveRoomMutation = () => {
   return useMutation({
     mutationFn: leaveRoom,

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -1,0 +1,20 @@
+import type { MeResponse } from '@/api/auth/auth.types';
+import { leaveRoom } from '@/api/room/room.api';
+import { useMutation } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
+import { queryKeys } from '@/lib/queryKeys';
+
+export const useLeaveRoomMutation = () => {
+  return useMutation({
+    mutationFn: leaveRoom,
+    onSuccess: () => {
+      queryClient.setQueryData(
+        queryKeys.auth.me,
+        (prev: MeResponse | undefined) =>
+          prev ? { ...prev, hasRoom: false } : prev
+      );
+      queryClient.removeQueries({ queryKey: queryKeys.room.myRoom });
+      queryClient.removeQueries({ queryKey: queryKeys.room.invitationCode });
+    },
+  });
+};

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -1,8 +1,15 @@
 import type { MeResponse } from '@/api/auth/auth.types';
-import { leaveRoom } from '@/api/room/room.api';
+import { createRoom, leaveRoom } from '@/api/room/room.api';
+import type { CreateRoomRequest } from '@/api/room/room.types';
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
+
+export const useCreateRoomMutation = () => {
+  return useMutation({
+    mutationFn: (payload: CreateRoomRequest) => createRoom(payload),
+  });
+};
 
 export const useLeaveRoomMutation = () => {
   return useMutation({

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -2,6 +2,7 @@ import type { MeResponse } from '@/api/auth/auth.types';
 import {
   createRoom,
   getInvitationCode,
+  getMyRoom,
   leaveRoom,
   reissueInvitationCode,
 } from '@/api/room/room.api';
@@ -13,6 +14,13 @@ import { queryKeys } from '@/lib/queryKeys';
 export const useCreateRoomMutation = () => {
   return useMutation({
     mutationFn: (payload: CreateRoomRequest) => createRoom(payload),
+  });
+};
+
+export const useMyRoomQuery = () => {
+  return useQuery({
+    queryKey: queryKeys.room.myRoom,
+    queryFn: getMyRoom,
   });
 };
 

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -3,10 +3,11 @@ import {
   createRoom,
   getInvitationCode,
   getMyRoom,
+  joinRoom,
   leaveRoom,
   reissueInvitationCode,
 } from '@/api/room/room.api';
-import type { CreateRoomRequest } from '@/api/room/room.types';
+import type { CreateRoomRequest, JoinRoomRequest } from '@/api/room/room.types';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
@@ -14,6 +15,12 @@ import { queryKeys } from '@/lib/queryKeys';
 export const useCreateRoomMutation = () => {
   return useMutation({
     mutationFn: (payload: CreateRoomRequest) => createRoom(payload),
+  });
+};
+
+export const useJoinRoomMutation = () => {
+  return useMutation({
+    mutationFn: (payload: JoinRoomRequest) => joinRoom(payload),
   });
 };
 

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -1,13 +1,34 @@
 import type { MeResponse } from '@/api/auth/auth.types';
-import { createRoom, leaveRoom } from '@/api/room/room.api';
+import {
+  createRoom,
+  getInvitationCode,
+  leaveRoom,
+  reissueInvitationCode,
+} from '@/api/room/room.api';
 import type { CreateRoomRequest } from '@/api/room/room.types';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
 
 export const useCreateRoomMutation = () => {
   return useMutation({
     mutationFn: (payload: CreateRoomRequest) => createRoom(payload),
+  });
+};
+
+export const useInvitationCodeQuery = () => {
+  return useQuery({
+    queryKey: queryKeys.room.invitationCode,
+    queryFn: getInvitationCode,
+  });
+};
+
+export const useReissueInvitationCodeMutation = () => {
+  return useMutation({
+    mutationFn: reissueInvitationCode,
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.room.invitationCode, data);
+    },
   });
 };
 

--- a/src/api/room/room.query.ts
+++ b/src/api/room/room.query.ts
@@ -19,6 +19,7 @@ export const useMyRoomQuery = () => {
   return useQuery({
     queryKey: queryKeys.room.myRoom,
     queryFn: getMyRoom,
+    staleTime: 1000 * 60 * 5,
   });
 };
 
@@ -27,6 +28,7 @@ export const useInvitationCodeQuery = () => {
   return useQuery({
     queryKey: queryKeys.room.invitationCode,
     queryFn: getInvitationCode,
+    staleTime: 1000 * 60,
   });
 };
 

--- a/src/api/room/room.types.ts
+++ b/src/api/room/room.types.ts
@@ -21,8 +21,8 @@ export type RoomResponse = {
   membersCount: number;
   score: number;
   invitationCode: string;
-  ruleWarningCount: string | null;
-  delayTaskCount: string | null;
+  ruleWarningCount: number | null;
+  delayTaskCount: number | null;
   members: RoomMemberResponse[];
   createdAt: string;
   updatedAt: string;
@@ -36,8 +36,8 @@ export type MyRoomResponse = {
   membersCount: number;
   score: number;
   invitationCode: string | null;
-  ruleWarningCount: string | null;
-  delayTaskCount: string | null;
+  ruleWarningCount: number | null;
+  delayTaskCount: number | null;
   members: RoomMemberResponse[];
   createdAt: string;
   updatedAt: string;
@@ -57,4 +57,5 @@ export type GetUsedProfileImagesResponse = {
 
 export type InvitationCodeResponse = {
   invitationCode: string;
+  reissueAvailableAt: string;
 };

--- a/src/hooks/useAuthGuardMe.ts
+++ b/src/hooks/useAuthGuardMe.ts
@@ -1,0 +1,33 @@
+import type { MeResponse } from '@/api/auth/auth.types';
+import { useAuthStore } from '@/stores/auth.store';
+import { useMeQuery } from '@/api/auth/auth.query';
+
+type UseAuthGuardMeResult = {
+  me: MeResponse | null;
+  isChecking: boolean; // 인증/사용자 조회 진행 중 여부
+  shouldRedirectToLogin: boolean; // 로그인으로 보내야 하는지 여부
+};
+
+/**
+ * 인증 라우트 가드에서 공통으로 사용하는 훅
+ * - accessToken + 인증 확인 완료 후 me 조회
+ * - 토큰 없음 / 쿼리 에러 / me 없음 → 로그인 리다이렉트 대상
+ */
+export const useAuthGuardMe = (): UseAuthGuardMeResult => {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
+
+  const {
+    data: me,
+    isLoading,
+    isError,
+  } = useMeQuery({
+    enabled: !!accessToken && isAuthChecked,
+  });
+
+  const isChecking = !isAuthChecked || (!!accessToken && isLoading);
+  const shouldRedirectToLogin =
+    isAuthChecked && (!accessToken || isError || (!isLoading && !me));
+
+  return { me: me ?? null, isChecking, shouldRedirectToLogin };
+};

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,3 @@
+export const queryKeys = {
+  me: ['me'] as const,
+};

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,3 +1,5 @@
 export const queryKeys = {
-  me: ['me'] as const,
+  auth: {
+    me: ['auth', 'me'] as const,
+  },
 };

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -2,4 +2,8 @@ export const queryKeys = {
   auth: {
     me: ['auth', 'me'] as const,
   },
+  room: {
+    myRoom: ['room', 'myRoom'] as const,
+    invitationCode: ['room', 'invitationCode'] as const,
+  },
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,16 @@ import '@/global.css';
 
 import App from '@/App';
 import { BrowserRouter } from 'react-router-dom';
+import QueryProvider from '@/providers/QueryProvider';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryProvider>
   </StrictMode>
 );

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,11 +1,10 @@
-import {
+﻿import {
   MOCK_MY_ID,
   MOCK_TODAY,
   PROFILE_IMAGE,
   mockTodoList,
 } from '@/mocks/mockData';
 import { addLocalToTodos, getTodoSections } from '@/utils/todos';
-import { useEffect, useState } from 'react';
 
 import DashboardSection from '@/pages/home/components/DashboardSection';
 import EmptyState from '@/components/common/EmptyState';
@@ -13,15 +12,15 @@ import ListItemCard from '@/components/common/ListItemCard';
 import ListSection from '@/components/common/ListSection';
 import MembersSection from '@/pages/home/components/MembersSection';
 import MottoSection from '@/pages/home/components/MottoSection';
-import type { MyRoomResponse } from '@/api/room/room.types';
 import UserAvatar from '@/components/common/UserAvatar';
 import { formatDueDateLabel } from '@/utils/date';
 import { getApiErrorMessage } from '@/api/error';
-import { getMyRoom } from '@/api/room/room.api';
 import { toast } from 'sonner';
+import { useEffect } from 'react';
+import { useMyRoomQuery } from '@/api/room/room.query';
 
 const HomePage = () => {
-  const [room, setRoom] = useState<MyRoomResponse | null>(null);
+  const { data: room, isError, error } = useMyRoomQuery();
 
   const myId = MOCK_MY_ID;
   const today = MOCK_TODAY;
@@ -35,21 +34,13 @@ const HomePage = () => {
   const missedCount = missedTodos.length;
 
   useEffect(() => {
-    const fetchMyRoom = async () => {
-      try {
-        const data = await getMyRoom();
-        console.log('내 방 조회: ', data);
-        setRoom(data);
-      } catch (error) {
-        const message = getApiErrorMessage(error);
+    if (!isError) return;
 
-        console.error('내 방 조회 실패:', message, error);
-        toast(message);
-      }
-    };
+    const message = getApiErrorMessage(error);
 
-    fetchMyRoom();
-  }, []);
+    console.error('우리 방 조회 실패:', message, error);
+    toast(message);
+  }, [isError, error]);
 
   return (
     <div className="space-y-4 p-4">

--- a/src/pages/login/AuthCallbackPage.tsx
+++ b/src/pages/login/AuthCallbackPage.tsx
@@ -2,6 +2,8 @@ import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getMe } from '@/api/auth/auth.api';
+import { queryClient } from '@/lib/queryClient';
+import { queryKeys } from '@/lib/queryKeys';
 import { useAuthStore } from '@/stores/auth.store';
 import { useEffect } from 'react';
 
@@ -36,7 +38,11 @@ const AuthCallbackPage = () => {
       window.history.replaceState({}, '', window.location.pathname);
 
       try {
-        const me = await getMe();
+        const me = await queryClient.fetchQuery({
+          queryKey: queryKeys.auth.me,
+          queryFn: getMe,
+        });
+
         setUser(me);
 
         // 약관 미동의 사용자는 약관 동의 화면으로 이동

--- a/src/pages/login/AuthCallbackPage.tsx
+++ b/src/pages/login/AuthCallbackPage.tsx
@@ -1,4 +1,4 @@
-import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
+﻿import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getMe } from '@/api/auth/auth.api';
@@ -12,7 +12,6 @@ const AuthCallbackPage = () => {
   const [searchParams] = useSearchParams();
 
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
-  const setUser = useAuthStore((state) => state.setUser);
   const clearAuth = useAuthStore((state) => state.clearAuth);
 
   useEffect(() => {
@@ -43,8 +42,6 @@ const AuthCallbackPage = () => {
           queryFn: getMe,
         });
 
-        setUser(me);
-
         // 약관 미동의 사용자는 약관 동의 화면으로 이동
         if (!hasAgreedToTerms(me)) {
           navigate('/signup/terms', { replace: true });
@@ -72,7 +69,7 @@ const AuthCallbackPage = () => {
     };
 
     initializeAuth();
-  }, [navigate, searchParams, setAccessToken, setUser, clearAuth]);
+  }, [navigate, searchParams, setAccessToken, clearAuth]);
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4">

--- a/src/pages/login/TermsPage.tsx
+++ b/src/pages/login/TermsPage.tsx
@@ -1,10 +1,9 @@
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import TermsAgreementSheet from '@/pages/login/components/TermsAgreementSheet';
-import { agreeToTerms } from '@/api/auth/auth.api';
 import { getApiErrorMessage } from '@/api/error';
 import { toast } from 'sonner';
-import { useAuthStore } from '@/stores/auth.store';
+import { useAgreeToTermsMutation } from '@/api/auth/auth.query';
 import { useState } from 'react';
 
 export type Agreements = {
@@ -16,9 +15,9 @@ export type Agreements = {
 const TermsPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const updateUser = useAuthStore((state) => state.updateUser);
+  const { mutateAsync: agreeToTermsMutate, isPending } =
+    useAgreeToTermsMutation();
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [agreements, setAgreements] = useState<Agreements>({
     age: false,
     service: false,
@@ -29,19 +28,13 @@ const TermsPage = () => {
 
   const handleAgree = async () => {
     try {
-      setIsSubmitting(true);
-
-      await agreeToTerms();
-
-      updateUser({ termsAgreed: true });
+      await agreeToTermsMutate();
 
       navigate('/signup/complete', { replace: true });
     } catch (error) {
       const message = getApiErrorMessage(error);
-      console.error(message);
+      console.error('이용약관 동의 처리 실패: ', message, error);
       toast(message || '이용약관 동의 처리에 실패했어요. 다시 시도해주세요.');
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -55,7 +48,7 @@ const TermsPage = () => {
               navigate(-1);
             }
           }}
-          isSubmitting={isSubmitting}
+          isSubmitting={isPending}
           agreements={agreements}
           onChangeAgreements={setAgreements}
           onAgree={handleAgree}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,24 +1,25 @@
+﻿import { useLogoutMutation, useMeQuery } from '@/api/auth/auth.query';
+import { useLeaveRoomMutation } from '@/api/room/room.query';
 import { Button } from '@/components/ui/button';
 import { HEADER_HEIGHT_CLASS } from '@/constants/layout';
-import { X } from 'lucide-react';
-import { leaveRoom } from '@/api/room/room.api';
-import { logout } from '@/api/auth/auth.api';
-import { toast } from 'sonner';
-import { useAuthStore } from '@/stores/auth.store';
-import { useNavigate } from 'react-router-dom';
 import { useOnboardingStore } from '@/stores/onboarding.store';
+import { useAuthStore } from '@/stores/auth.store';
+import { X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 const MyPage = () => {
   const navigate = useNavigate();
 
-  const user = useAuthStore((state) => state.user);
-  const updateUser = useAuthStore((state) => state.updateUser);
+  const { data: me } = useMeQuery();
+  const { mutateAsync: logoutMutate } = useLogoutMutation();
+  const { mutateAsync: leaveRoomMutate } = useLeaveRoomMutation();
   const clearAuth = useAuthStore((state) => state.clearAuth);
   const resetOnboarding = useOnboardingStore((state) => state.resetOnboarding);
 
   const handleLogout = async () => {
     try {
-      await logout();
+      await logoutMutate();
 
       resetOnboarding();
       clearAuth();
@@ -31,17 +32,16 @@ const MyPage = () => {
 
   const handleLeaveRoom = async () => {
     try {
-      await leaveRoom();
+      await leaveRoomMutate();
 
       resetOnboarding();
-      updateUser({ hasRoom: false });
 
       toast('방에서 나갔어요.');
 
       navigate('/onboarding', { replace: true });
     } catch (error) {
       console.error('방 나가기 실패:', error);
-      toast('방 나가기에 실패했어요.');
+      toast('방 나가기에 실패했어요');
     }
   };
 
@@ -65,8 +65,8 @@ const MyPage = () => {
 
       <section className="flex flex-col items-center py-4">
         프로필
-        <p className="text-lg font-semibold">{user?.nickname ?? '-'}</p>
-        <p className="text-sm text-neutral-500">{user?.email ?? '-'}</p>
+        <p className="text-lg font-semibold">{me?.nickname ?? '-'}</p>
+        <p className="text-sm text-neutral-500">{me?.email ?? '-'}</p>
       </section>
 
       <div className="bg-secondary h-[13px]" />

--- a/src/pages/mypage/RoomInvitationPage.tsx
+++ b/src/pages/mypage/RoomInvitationPage.tsx
@@ -1,49 +1,47 @@
-import { getInvitationCode, reissueInvitationCode } from '@/api/room/room.api';
-import { useEffect, useState } from 'react';
+﻿import {
+  useInvitationCodeQuery,
+  useReissueInvitationCodeMutation,
+} from '@/api/room/room.query';
 
 import BackHeader from '@/components/layout/BackHeader';
 import { Button } from '@/components/ui/button';
 import InviteCodeCard from '@/components/common/InviteCodeCard';
 import { getApiErrorMessage } from '@/api/error';
 import { toast } from 'sonner';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const RoomInvitationPage = () => {
   const navigate = useNavigate();
-  const [inviteCode, setInviteCode] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+
+  const {
+    data: invitationCodeData,
+    isLoading,
+    isError,
+    error,
+  } = useInvitationCodeQuery();
+  const { mutateAsync: reissueMutate, isPending: isReissuing } =
+    useReissueInvitationCodeMutation();
+
+  const inviteCode = invitationCodeData?.invitationCode ?? '';
 
   useEffect(() => {
-    const fetchInvitationCode = async () => {
-      try {
-        setIsLoading(true);
+    if (!isError) return;
 
-        const { invitationCode } = await getInvitationCode();
-        setInviteCode(invitationCode);
-      } catch (error) {
-        const message = getApiErrorMessage(error);
+    const message = getApiErrorMessage(error);
 
-        console.error('초대 코드 조회 실패: ', message, error);
-        toast(message, {
-          id: 'invitation-code-error',
-          duration: 2000,
-        });
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchInvitationCode();
-  }, []);
+    console.error('초대 코드 조회 실패: ', message, error);
+    toast(message, {
+      id: 'invitation-code-error',
+      duration: 2000,
+    });
+  }, [isError, error]);
 
   const handleReissue = async () => {
     try {
-      setIsLoading(true);
+      await reissueMutate();
 
-      const { invitationCode } = await reissueInvitationCode();
-      setInviteCode(invitationCode);
-
-      toast('초대 코드가 재발급되었어요', {
+      toast('초대 코드가 재발급되었어요.', {
         id: 'reissue-invitation-code-success',
         duration: 2000,
       });
@@ -55,8 +53,6 @@ const RoomInvitationPage = () => {
         id: 'reissue-invitation-code-error',
         duration: 2000,
       });
-    } finally {
-      setIsLoading(false);
     }
   };
 
@@ -80,7 +76,7 @@ const RoomInvitationPage = () => {
 
         <Button
           onClick={handleReissue}
-          disabled={isLoading || !inviteCode}
+          disabled={isLoading || isReissuing || !inviteCode}
           className="bg-muted-foreground rounded-lg"
         >
           코드 재발급 하기

--- a/src/pages/onboarding/CreateHousePage.tsx
+++ b/src/pages/onboarding/CreateHousePage.tsx
@@ -1,3 +1,5 @@
+﻿import { useMeQuery, useUpdateMeMutation } from '@/api/auth/auth.query';
+
 import { Button } from '@/components/ui/button';
 import HouseWelcomeDialog from '@/pages/onboarding/components/HouseWelcomeDialog';
 import InviteCodeStep from '@/pages/onboarding/components/InviteCodeStep';
@@ -5,11 +7,11 @@ import MottoStep from '@/pages/onboarding/components/MottoStep';
 import OnboardingFlowLayout from '@/pages/onboarding/components/OnboardingFlowLayout';
 import ProfileStep from '@/pages/onboarding/components/ProfileStep';
 import type { RoomResponse } from '@/api/room/room.types';
-import { createRoom } from '@/api/room/room.api';
 import { getApiErrorMessage } from '@/api/error';
+import { queryClient } from '@/lib/queryClient';
+import { queryKeys } from '@/lib/queryKeys';
 import { toast } from 'sonner';
-import { updateMe } from '@/api/auth/auth.api';
-import { useAuthStore } from '@/stores/auth.store';
+import { useCreateRoomMutation } from '@/api/room/room.query';
 import { useNavigate } from 'react-router-dom';
 import { useOnboardingStore } from '@/stores/onboarding.store';
 import { useState } from 'react';
@@ -29,12 +31,12 @@ const CreateHousePage = () => {
   } = useOnboardingStore();
 
   const { step, motto, nickname, selectedProfileId } = createFlow;
-
-  const userNickname = useAuthStore((state) => state.user?.nickname);
-  const updateUser = useAuthStore((state) => state.updateUser);
+  const { data: me } = useMeQuery();
+  const { mutateAsync: updateMeMutate } = useUpdateMeMutation();
+  const { mutateAsync: createRoomMutate } = useCreateRoomMutation();
 
   const getSafeNickname = (value: string) => {
-    return value.trim() || userNickname || '';
+    return value.trim() || me?.nickname || '';
   };
 
   const moveToInvite = async () => {
@@ -43,28 +45,22 @@ const CreateHousePage = () => {
       return;
     }
 
-    const room = await createRoom({
+    const room = await createRoomMutate({
       name: null,
       motto: motto.trim() || null,
     });
-
-    console.log('방 생성 응답:', room);
 
     setCreatedRoom(room);
     setCreateStep('invite');
   };
 
   const submitProfile = async () => {
-    const safeNickName = getSafeNickname(nickname);
+    const safeNickname = getSafeNickname(nickname);
 
-    const updatedUser = await updateMe({
-      nickname: safeNickName,
+    await updateMeMutate({
+      nickname: safeNickname,
       profileImageUrl: selectedProfileId,
     });
-
-    console.log('내 정보 수정 응답:', updatedUser);
-
-    updateUser(updatedUser);
   };
 
   const handleBack = () => {
@@ -78,9 +74,7 @@ const CreateHousePage = () => {
       return;
     }
 
-    // motto 단계일 때
     navigate('/onboarding');
-    return;
   };
 
   const handleNext = async () => {
@@ -111,7 +105,6 @@ const CreateHousePage = () => {
       return;
     }
 
-    // invite 단계일 때
     setIsCompleteOpen(true);
   };
 
@@ -147,7 +140,7 @@ const CreateHousePage = () => {
   };
 
   const handleConfirm = async () => {
-    updateUser({ hasRoom: true });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
 
     resetOnboarding();
     navigate('/home', { replace: true });

--- a/src/pages/onboarding/JoinHousePage.tsx
+++ b/src/pages/onboarding/JoinHousePage.tsx
@@ -1,10 +1,7 @@
-import { OTP_LENGTH, PROFILE_OPTIONS } from '@/constants/onboarding';
+﻿import { OTP_LENGTH, PROFILE_OPTIONS } from '@/constants/onboarding';
 import type { RoomMemberResponse, RoomResponse } from '@/api/room/room.types';
-import {
-  getRoomMembers,
-  getUsedProfileImages,
-  joinRoom,
-} from '@/api/room/room.api';
+import { getRoomMembers, joinRoom } from '@/api/room/room.api';
+import { useMeQuery, useUpdateMeMutation } from '@/api/auth/auth.query';
 
 import { Button } from '@/components/ui/button';
 import HouseConfirmStep from '@/pages/onboarding/components/HouseConfirmStep';
@@ -13,8 +10,6 @@ import OnboardingFlowLayout from '@/pages/onboarding/components/OnboardingFlowLa
 import ProfileStep from '@/pages/onboarding/components/ProfileStep';
 import { getApiErrorMessage } from '@/api/error';
 import { toast } from 'sonner';
-import { updateMe } from '@/api/auth/auth.api';
-import { useAuthStore } from '@/stores/auth.store';
 import { useNavigate } from 'react-router-dom';
 import { useOnboardingStore } from '@/stores/onboarding.store';
 import { useState } from 'react';
@@ -36,25 +31,20 @@ const JoinHousePage = () => {
   } = useOnboardingStore();
 
   const { step, inviteCode, nickname, selectedProfileId } = joinFlow;
-
-  const userNickname = useAuthStore((state) => state.user?.nickname);
-  const updateUser = useAuthStore((state) => state.updateUser);
+  const { data: me } = useMeQuery();
+  const { mutateAsync: updateMeMutate } = useUpdateMeMutation();
 
   const getSafeNickname = (value: string) => {
-    return value.trim() || userNickname || '';
+    return value.trim() || me?.nickname || '';
   };
 
   const submitProfile = async () => {
     const safeNickname = getSafeNickname(nickname);
 
-    const updatedUser = await updateMe({
+    await updateMeMutate({
       nickname: safeNickname,
       profileImageUrl: selectedProfileId,
     });
-
-    console.log('내 정보 수정 응답:', updatedUser);
-
-    updateUser(updatedUser);
   };
 
   const handleChangeInviteCode = (value: string) => {
@@ -98,7 +88,6 @@ const JoinHousePage = () => {
       setIsSubmitting(true);
 
       await submitProfile();
-      updateUser({ hasRoom: true });
 
       resetOnboarding();
       navigate('/home', { replace: true });
@@ -129,9 +118,6 @@ const JoinHousePage = () => {
         const room = await joinRoom({ invitationCode: inviteCode });
         const roomMembers = await getRoomMembers({ excludeMe: true });
 
-        console.log('방 입장: ', room);
-        console.log('방 구성원: ', roomMembers);
-
         setJoinedRoom(room);
         setMembers(roomMembers);
         setHasError(false);
@@ -154,40 +140,24 @@ const JoinHousePage = () => {
     }
 
     if (step === 'confirm') {
-      try {
-        setIsSubmitting(true);
+      const usedByOthers = members.map((member) => member.profileImageUrl);
 
-        const { usedImages } = await getUsedProfileImages();
-        console.log('사용 중인 프로필 id: ', usedImages);
+      setUsedProfileIds(usedByOthers);
 
-        const usedByOthers = members.map((member) => member.profileImageUrl);
-        setUsedProfileIds(usedByOthers);
+      const isCurrentSelectedUsedByOthers =
+        usedByOthers.includes(selectedProfileId);
 
-        const isCurrentSelectedUsed = usedImages.includes(selectedProfileId);
+      if (isCurrentSelectedUsedByOthers) {
+        const availableProfile = PROFILE_OPTIONS.find(
+          (profile) => !usedByOthers.includes(profile.id)
+        );
 
-        if (isCurrentSelectedUsed) {
-          const availableProfile = PROFILE_OPTIONS.find(
-            (profile) => !usedImages.includes(profile.id)
-          );
-
-          if (availableProfile) {
-            updateJoinFlow({ selectedProfileId: availableProfile.id });
-          }
+        if (availableProfile) {
+          updateJoinFlow({ selectedProfileId: availableProfile.id });
         }
-
-        setJoinStep('profile');
-      } catch (error) {
-        const message = getApiErrorMessage(error);
-
-        console.error('사용 중인 프로필 이미지 조회 실패: ', message, error);
-
-        toast(message, {
-          id: 'used-profile-images-error',
-          duration: 2000,
-        });
-      } finally {
-        setIsSubmitting(false);
       }
+
+      setJoinStep('profile');
 
       return;
     }

--- a/src/pages/onboarding/JoinHousePage.tsx
+++ b/src/pages/onboarding/JoinHousePage.tsx
@@ -8,7 +8,6 @@ import InviteCodeInputStep from '@/pages/onboarding/components/InviteCodeInputSt
 import OnboardingFlowLayout from '@/pages/onboarding/components/OnboardingFlowLayout';
 import ProfileStep from '@/pages/onboarding/components/ProfileStep';
 import { getApiErrorMessage } from '@/api/error';
-import { getRoomMembers } from '@/api/room/room.api';
 import { toast } from 'sonner';
 import { useJoinRoomMutation } from '@/api/room/room.query';
 import { useNavigate } from 'react-router-dom';
@@ -118,7 +117,9 @@ const JoinHousePage = () => {
         setIsSubmitting(true);
 
         const room = await joinRoomMutate({ invitationCode: inviteCode });
-        const roomMembers = await getRoomMembers({ excludeMe: true });
+        const roomMembers = room.members.filter(
+          (member) => member.id !== me?.id
+        );
 
         setJoinedRoom(room);
         setMembers(roomMembers);

--- a/src/pages/onboarding/JoinHousePage.tsx
+++ b/src/pages/onboarding/JoinHousePage.tsx
@@ -1,6 +1,5 @@
 ﻿import { OTP_LENGTH, PROFILE_OPTIONS } from '@/constants/onboarding';
 import type { RoomMemberResponse, RoomResponse } from '@/api/room/room.types';
-import { getRoomMembers, joinRoom } from '@/api/room/room.api';
 import { useMeQuery, useUpdateMeMutation } from '@/api/auth/auth.query';
 
 import { Button } from '@/components/ui/button';
@@ -9,7 +8,9 @@ import InviteCodeInputStep from '@/pages/onboarding/components/InviteCodeInputSt
 import OnboardingFlowLayout from '@/pages/onboarding/components/OnboardingFlowLayout';
 import ProfileStep from '@/pages/onboarding/components/ProfileStep';
 import { getApiErrorMessage } from '@/api/error';
+import { getRoomMembers } from '@/api/room/room.api';
 import { toast } from 'sonner';
+import { useJoinRoomMutation } from '@/api/room/room.query';
 import { useNavigate } from 'react-router-dom';
 import { useOnboardingStore } from '@/stores/onboarding.store';
 import { useState } from 'react';
@@ -33,6 +34,7 @@ const JoinHousePage = () => {
   const { step, inviteCode, nickname, selectedProfileId } = joinFlow;
   const { data: me } = useMeQuery();
   const { mutateAsync: updateMeMutate } = useUpdateMeMutation();
+  const { mutateAsync: joinRoomMutate } = useJoinRoomMutation();
 
   const getSafeNickname = (value: string) => {
     return value.trim() || me?.nickname || '';
@@ -115,7 +117,7 @@ const JoinHousePage = () => {
       try {
         setIsSubmitting(true);
 
-        const room = await joinRoom({ invitationCode: inviteCode });
+        const room = await joinRoomMutate({ invitationCode: inviteCode });
         const roomMembers = await getRoomMembers({ excludeMe: true });
 
         setJoinedRoom(room);

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -1,6 +1,6 @@
 import AppButton from '@/components/common/AppButton';
+import { useMeQuery } from '@/api/auth/auth.query';
 import dzipsaCharacter from '@/assets/dzipsa.svg';
-import { useAuthStore } from '@/stores/auth.store';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useOnboardingStore } from '@/stores/onboarding.store';
@@ -8,7 +8,8 @@ import { useOnboardingStore } from '@/stores/onboarding.store';
 const OnboardingPage = () => {
   const navigate = useNavigate();
 
-  const userNickname = useAuthStore((state) => state.user?.nickname);
+  const { data: me } = useMeQuery();
+  const userNickname = me?.nickname;
   const initializeNicknames = useOnboardingStore(
     (state) => state.initializeNicknames
   );

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from '@/lib/queryClient';
+
+type QueryProviderProps = {
+  children: ReactNode;
+};
+
+const QueryProvider = ({ children }: QueryProviderProps) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  );
+};
+
+export default QueryProvider;

--- a/src/routes/AppEntryRoute.tsx
+++ b/src/routes/AppEntryRoute.tsx
@@ -1,38 +1,19 @@
-// 약관에 동의하고 방에 소속된 사용자만
-// 메인 앱 영역(/home 등)에 접근할 수 있도록 제한
-
-import { Navigate, Outlet } from 'react-router-dom';
+﻿import { Navigate, Outlet } from 'react-router-dom';
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
-import { useAuthStore } from '@/stores/auth.store';
-import { useMeQuery } from '@/api/auth/auth.query';
+import { useAuthGuardMe } from '@/hooks/useAuthGuardMe';
 
+// 앱 메인 영역 가드: 약관 동의 + 방 소속 사용자만 접근 허용
 const AppEntryRoute = () => {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
-  const {
-    data: me,
-    isLoading,
-    isError,
-  } = useMeQuery({
-    enabled: !!accessToken && isAuthChecked,
-  });
+  const { me, isChecking, shouldRedirectToLogin } = useAuthGuardMe();
 
-  if (!isAuthChecked) return null;
+  if (isChecking) return null;
 
-  if (!accessToken) {
+  // 인증 정보가 유효하지 않으면 로그인으로 이동
+  if (shouldRedirectToLogin || !me) {
     return <Navigate to="/login" replace />;
   }
 
-  if (isLoading) return null;
-
-  if (isError) {
-    return <Navigate to="/login" replace />;
-  }
-
-  if (!me) {
-    return <Navigate to="/login" replace />;
-  }
   if (!hasAgreedToTerms(me)) {
     return <Navigate to="/signup/terms" replace />;
   }

--- a/src/routes/AppEntryRoute.tsx
+++ b/src/routes/AppEntryRoute.tsx
@@ -5,15 +5,39 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
 import { useAuthStore } from '@/stores/auth.store';
+import { useMeQuery } from '@/api/auth/auth.query';
 
 const AppEntryRoute = () => {
-  const user = useAuthStore((state) => state.user);
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
+  const {
+    data: me,
+    isLoading,
+    isError,
+  } = useMeQuery({
+    enabled: !!accessToken && isAuthChecked,
+  });
 
-  if (!hasAgreedToTerms(user)) {
+  if (!isAuthChecked) return null;
+
+  if (!accessToken) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isLoading) return null;
+
+  if (isError) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!me) {
+    return <Navigate to="/login" replace />;
+  }
+  if (!hasAgreedToTerms(me)) {
     return <Navigate to="/signup/terms" replace />;
   }
 
-  if (!hasRoom(user)) {
+  if (!hasRoom(me)) {
     return <Navigate to="/onboarding" replace />;
   }
 

--- a/src/routes/AuthInitializer.tsx
+++ b/src/routes/AuthInitializer.tsx
@@ -2,6 +2,8 @@ import { getMe, refresh } from '@/api/auth/auth.api';
 import { useEffect, useRef, useState } from 'react';
 
 import { Outlet } from 'react-router-dom';
+import { queryClient } from '@/lib/queryClient';
+import { queryKeys } from '@/lib/queryKeys';
 import { useAuthStore } from '@/stores/auth.store';
 
 const AuthInitializer = () => {
@@ -23,7 +25,11 @@ const AuthInitializer = () => {
         const { accessToken } = await refresh();
         setAccessToken(accessToken);
 
-        const me = await getMe();
+        const me = await queryClient.fetchQuery({
+          queryKey: queryKeys.me,
+          queryFn: getMe,
+        });
+
         setUser(me);
       } catch (error) {
         console.error('초기 인증 실패:', error);

--- a/src/routes/AuthInitializer.tsx
+++ b/src/routes/AuthInitializer.tsx
@@ -26,7 +26,7 @@ const AuthInitializer = () => {
         setAccessToken(accessToken);
 
         const me = await queryClient.fetchQuery({
-          queryKey: queryKeys.me,
+          queryKey: queryKeys.auth.me,
           queryFn: getMe,
         });
 

--- a/src/routes/AuthInitializer.tsx
+++ b/src/routes/AuthInitializer.tsx
@@ -1,7 +1,7 @@
 import { getMe, refresh } from '@/api/auth/auth.api';
 import { useEffect, useRef, useState } from 'react';
 
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
 import { useAuthStore } from '@/stores/auth.store';
@@ -9,6 +9,7 @@ import { useAuthStore } from '@/stores/auth.store';
 const AuthInitializer = () => {
   const [isInitializing, setIsInitializing] = useState(true);
   const hasInitialized = useRef(false);
+  const { pathname } = useLocation();
 
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const setUser = useAuthStore((state) => state.setUser);
@@ -19,6 +20,12 @@ const AuthInitializer = () => {
     // 이미 초기화가 진행되었으면 중복 실행 방지
     if (hasInitialized.current) return;
     hasInitialized.current = true;
+
+    if (pathname.startsWith('/auth/callback')) {
+      setAuthChecked(true);
+      setIsInitializing(false);
+      return;
+    }
 
     const initializeAuth = async () => {
       try {
@@ -41,7 +48,7 @@ const AuthInitializer = () => {
     };
 
     initializeAuth();
-  }, [setAccessToken, setUser, setAuthChecked, clearAuth]);
+  }, [pathname, setAccessToken, setUser, setAuthChecked, clearAuth]);
 
   if (isInitializing) {
     return (

--- a/src/routes/AuthInitializer.tsx
+++ b/src/routes/AuthInitializer.tsx
@@ -1,7 +1,7 @@
+﻿import { Outlet, useLocation } from 'react-router-dom';
 import { getMe, refresh } from '@/api/auth/auth.api';
 import { useEffect, useRef, useState } from 'react';
 
-import { Outlet, useLocation } from 'react-router-dom';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
 import { useAuthStore } from '@/stores/auth.store';
@@ -12,7 +12,6 @@ const AuthInitializer = () => {
   const { pathname } = useLocation();
 
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
-  const setUser = useAuthStore((state) => state.setUser);
   const setAuthChecked = useAuthStore((state) => state.setAuthChecked);
   const clearAuth = useAuthStore((state) => state.clearAuth);
 
@@ -32,12 +31,10 @@ const AuthInitializer = () => {
         const { accessToken } = await refresh();
         setAccessToken(accessToken);
 
-        const me = await queryClient.fetchQuery({
+        await queryClient.fetchQuery({
           queryKey: queryKeys.auth.me,
           queryFn: getMe,
         });
-
-        setUser(me);
       } catch (error) {
         console.error('초기 인증 실패:', error);
         clearAuth();
@@ -48,7 +45,7 @@ const AuthInitializer = () => {
     };
 
     initializeAuth();
-  }, [pathname, setAccessToken, setUser, setAuthChecked, clearAuth]);
+  }, [pathname, setAccessToken, setAuthChecked, clearAuth]);
 
   if (isInitializing) {
     return (

--- a/src/routes/OnboardingRoute.tsx
+++ b/src/routes/OnboardingRoute.tsx
@@ -2,15 +2,40 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
 import { useAuthStore } from '@/stores/auth.store';
+import { useMeQuery } from '@/api/auth/auth.query';
 
 const OnboardingRoute = () => {
-  const user = useAuthStore((state) => state.user);
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
+  const {
+    data: me,
+    isLoading,
+    isError,
+  } = useMeQuery({
+    enabled: !!accessToken && isAuthChecked,
+  });
 
-  if (!hasAgreedToTerms(user)) {
+  if (!isAuthChecked) return null;
+
+  if (!accessToken) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isLoading) return null;
+
+  if (isError) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!me) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!hasAgreedToTerms(me)) {
     return <Navigate to="/signup/terms" replace />;
   }
 
-  if (hasRoom(user)) {
+  if (hasRoom(me)) {
     return <Navigate to="/home" replace />;
   }
 

--- a/src/routes/OnboardingRoute.tsx
+++ b/src/routes/OnboardingRoute.tsx
@@ -1,33 +1,16 @@
-import { Navigate, Outlet } from 'react-router-dom';
+﻿import { Navigate, Outlet } from 'react-router-dom';
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
-import { useAuthStore } from '@/stores/auth.store';
-import { useMeQuery } from '@/api/auth/auth.query';
+import { useAuthGuardMe } from '@/hooks/useAuthGuardMe';
 
+// 온보딩 가드: 약관 미동의/이미 방 보유 사용자의 접근을 제어
 const OnboardingRoute = () => {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
-  const {
-    data: me,
-    isLoading,
-    isError,
-  } = useMeQuery({
-    enabled: !!accessToken && isAuthChecked,
-  });
+  const { me, isChecking, shouldRedirectToLogin } = useAuthGuardMe();
 
-  if (!isAuthChecked) return null;
+  if (isChecking) return null;
 
-  if (!accessToken) {
-    return <Navigate to="/login" replace />;
-  }
-
-  if (isLoading) return null;
-
-  if (isError) {
-    return <Navigate to="/login" replace />;
-  }
-
-  if (!me) {
+  // 인증 정보가 유효하지 않으면 로그인으로 이동
+  if (shouldRedirectToLogin || !me) {
     return <Navigate to="/login" replace />;
   }
 

--- a/src/routes/RootRedirect.tsx
+++ b/src/routes/RootRedirect.tsx
@@ -1,29 +1,52 @@
-// 루트 경로("/") 접근 시 로그인 여부에 따라 초기 페이지로 분기
+// 루트 경로("/") 접근 시 인증/온보딩 상태에 따라 초기 진입 페이지로 분기
 
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/auth.store';
+import { useMeQuery } from '@/api/auth/auth.query';
 
 const RootRedirect = () => {
   const accessToken = useAuthStore((state) => state.accessToken);
   const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
-  const user = useAuthStore((state) => state.user);
+  const {
+    data: me,
+    isLoading,
+    isError,
+  } = useMeQuery({
+    enabled: !!accessToken && isAuthChecked,
+  });
 
+  // AuthInitializer에서 인증 확인이 끝나기 전까지는 분기하지 않음
   if (!isAuthChecked) return null;
 
+  // accessToken이 없으면 로그인 페이지로 이동
   if (!accessToken) {
     return <Navigate to="/login" replace />;
   }
 
-  if (!hasAgreedToTerms(user)) {
+  // accessToken은 있지만 me 조회가 아직 끝나지 않았으면 대기
+  if (isLoading) return null;
+
+  // me 조회 실패 시 로그인 페이지로 이동
+  if (isError) {
+    return <Navigate to="/login" replace />;
+  }
+
+  // 예외적으로 me가 아직 없으면 분기 보류
+  if (!me) return null;
+
+  // 약관 미동의 사용자는 약관 동의 페이지로 이동
+  if (!hasAgreedToTerms(me)) {
     return <Navigate to="/signup/terms" replace />;
   }
 
-  if (!hasRoom(user)) {
+  // 방 미소속 사용자는 온보딩으로 이동
+  if (!hasRoom(me)) {
     return <Navigate to="/onboarding" replace />;
   }
 
+  // 인증 및 초기 조건을 모두 만족하면 홈으로 이동
   return <Navigate to="/home" replace />;
 };
 

--- a/src/routes/RootRedirect.tsx
+++ b/src/routes/RootRedirect.tsx
@@ -1,52 +1,27 @@
-// 루트 경로("/") 접근 시 인증/온보딩 상태에 따라 초기 진입 페이지로 분기
-
-import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
+﻿import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
 import { Navigate } from 'react-router-dom';
-import { useAuthStore } from '@/stores/auth.store';
-import { useMeQuery } from '@/api/auth/auth.query';
+import { useAuthGuardMe } from '@/hooks/useAuthGuardMe';
 
+// 루트 경로("/") 접근 시 인증/온보딩 상태에 따라 초기 진입 페이지로 분기
 const RootRedirect = () => {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
-  const {
-    data: me,
-    isLoading,
-    isError,
-  } = useMeQuery({
-    enabled: !!accessToken && isAuthChecked,
-  });
+  const { me, isChecking, shouldRedirectToLogin } = useAuthGuardMe();
 
-  // AuthInitializer에서 인증 확인이 끝나기 전까지는 분기하지 않음
-  if (!isAuthChecked) return null;
+  if (isChecking) return null;
 
-  // accessToken이 없으면 로그인 페이지로 이동
-  if (!accessToken) {
+  // 인증 정보가 유효하지 않으면 로그인으로 이동
+  if (shouldRedirectToLogin || !me) {
     return <Navigate to="/login" replace />;
   }
 
-  // accessToken은 있지만 me 조회가 아직 끝나지 않았으면 대기
-  if (isLoading) return null;
-
-  // me 조회 실패 시 로그인 페이지로 이동
-  if (isError) {
-    return <Navigate to="/login" replace />;
-  }
-
-  // 예외적으로 me가 아직 없으면 분기 보류
-  if (!me) return null;
-
-  // 약관 미동의 사용자는 약관 동의 페이지로 이동
   if (!hasAgreedToTerms(me)) {
     return <Navigate to="/signup/terms" replace />;
   }
 
-  // 방 미소속 사용자는 온보딩으로 이동
   if (!hasRoom(me)) {
     return <Navigate to="/onboarding" replace />;
   }
 
-  // 인증 및 초기 조건을 모두 만족하면 홈으로 이동
   return <Navigate to="/home" replace />;
 };
 

--- a/src/routes/TermsRoute.tsx
+++ b/src/routes/TermsRoute.tsx
@@ -1,33 +1,16 @@
-import { Navigate, Outlet } from 'react-router-dom';
+﻿import { Navigate, Outlet } from 'react-router-dom';
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
-import { useAuthStore } from '@/stores/auth.store';
-import { useMeQuery } from '@/api/auth/auth.query';
+import { useAuthGuardMe } from '@/hooks/useAuthGuardMe';
 
+// 약관 페이지 가드: 약관 완료 사용자는 terms 접근 대신 다음 단계로 보냄
 const TermsRoute = () => {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
-  const {
-    data: me,
-    isLoading,
-    isError,
-  } = useMeQuery({
-    enabled: !!accessToken && isAuthChecked,
-  });
+  const { me, isChecking, shouldRedirectToLogin } = useAuthGuardMe();
 
-  if (!isAuthChecked) return null;
+  if (isChecking) return null;
 
-  if (!accessToken) {
-    return <Navigate to="/login" replace />;
-  }
-
-  if (isLoading) return null;
-
-  if (isError) {
-    return <Navigate to="/login" replace />;
-  }
-
-  if (!me) {
+  // 인증 정보가 유효하지 않으면 로그인으로 이동
+  if (shouldRedirectToLogin || !me) {
     return <Navigate to="/login" replace />;
   }
 

--- a/src/routes/TermsRoute.tsx
+++ b/src/routes/TermsRoute.tsx
@@ -2,12 +2,37 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { hasAgreedToTerms, hasRoom } from '@/api/auth/auth.utils';
 
 import { useAuthStore } from '@/stores/auth.store';
+import { useMeQuery } from '@/api/auth/auth.query';
 
 const TermsRoute = () => {
-  const user = useAuthStore((state) => state.user);
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthChecked = useAuthStore((state) => state.isAuthChecked);
+  const {
+    data: me,
+    isLoading,
+    isError,
+  } = useMeQuery({
+    enabled: !!accessToken && isAuthChecked,
+  });
 
-  if (hasAgreedToTerms(user)) {
-    if (hasRoom(user)) {
+  if (!isAuthChecked) return null;
+
+  if (!accessToken) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isLoading) return null;
+
+  if (isError) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!me) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (hasAgreedToTerms(me)) {
+    if (hasRoom(me)) {
       return <Navigate to="/home" replace />;
     }
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,37 +1,22 @@
-import type { MeResponse } from '@/api/auth/auth.types';
-import { create } from 'zustand';
+﻿import { create } from 'zustand';
 
 type AuthState = {
   accessToken: string | null;
-  user: MeResponse | null;
   isAuthChecked: boolean; // 인증 확인 여부
 
   setAccessToken: (token: string | null) => void;
-  setUser: (user: MeResponse | null) => void;
-  updateUser: (payload: Partial<MeResponse>) => void;
   setAuthChecked: (checked: boolean) => void;
   clearAuth: () => void;
 };
 
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
-  user: null,
   isAuthChecked: false,
 
   setAccessToken: (token) =>
     set({
       accessToken: token,
     }),
-
-  setUser: (user) =>
-    set({
-      user,
-    }),
-
-  updateUser: (payload) =>
-    set((state) => ({
-      user: state.user ? { ...state.user, ...payload } : state.user,
-    })),
 
   setAuthChecked: (checked) =>
     set({
@@ -41,7 +26,6 @@ export const useAuthStore = create<AuthState>((set) => ({
   clearAuth: () =>
     set({
       accessToken: null,
-      user: null,
       isAuthChecked: true,
     }),
 }));


### PR DESCRIPTION
## PR 개요
- Room/Auth 도메인의 서버 상태 관리 방식을 `useState`/`useEffect` 기반에서 TanStack Query 기반 구조로 전환
  - 서버 상태와 클라이언트 상태(zustand)의 역할을 분리하고
  - 인증/방 관련 조회 및 변경 로직을 query/mutation 훅으로 통합하며
  - mutation 이후 데이터 최신화 흐름을 일관된 방식으로 정리함

## 변경 사항
### 1. TanStack Query 도입 및 전역 설정
- TanStack Query 및 Devtools 패키지 설치
- `QueryClientProvider` 전역 적용
- `queryKeys`에 `auth`, `room` 네임스페이스 정의

### 2. Auth 도메인 구조 개선
- `getMe`를 `useMeQuery` 기반으로 전환
- `AuthInitializer`, `AuthCallbackPage`를 `me` 쿼리 기준으로 정리
- `RootRedirect`, `TermsRoute`, `OnboardingRoute`, `AppEntryRoute`를 `useMeQuery` 기반 분기 구조로 전환
- 인증 라우트 가드 공통 로직을 `useAuthGuardMe` 훅으로 분리
- auth store에서 `user` 상태 제거 (`me` 쿼리 단일화)

### 3. Room 도메인 query/mutation 전환
- `getMyRoom` → `useMyRoomQuery`
- `getInvitationCode` → `useInvitationCodeQuery`
- `joinRoom`, `createRoom`, `leaveRoom`, `reissueInvitationCode`를 `useMutation` 기반으로 정리
- `JoinHousePage`, `CreateHousePage`, `RoomInvitationPage`, `HomePage`를 query 기반 구조로 전환
- `JoinHousePage`에서 `getRoomMembers` 제거 및 `joinRoom` 응답 데이터 재활용

### 4. Mutation 이후 캐시 동기화 정리
- `setQueryData`, `removeQueries` 기반으로 최신화 흐름 통일
- 로그아웃 / 방 나가기 / 약관 동의 / 프로필 수정 시 관련 캐시 즉시 반영

### 5. 캐시 전략 개선
- `auth.me`, `room.myRoom`에 `staleTime`(5분) 설정
- `room.invitationCode`에 `staleTime`(1분) 설정
- 불필요한 자동 refetch 방지

### 6. API 응답 타입 변경 반영
- `ruleWarningCount`, `delayTaskCount` 타입을 `string` → `number`로 수정
- `InvitationCodeResponse`에 `reissueAvailableAt` 필드 추가

## 추후 할 일
- [x] 규칙 페이지 디자인 적용
- [ ] 규칙 페이지 API 연동

## Related Issue
Closes #25 
