### PR TITLE
[feat] 할 일 등록/편집 화면 최종 디자인 반영

### DIFF
--- a/src/components/form/FormPageLayout.tsx
+++ b/src/components/form/FormPageLayout.tsx
@@ -33,7 +33,7 @@ const FormPageLayout = ({
     <div className="min-h-dvh bg-zinc-100">
       <header
         className={cn(
-          'fixed top-0 flex w-full items-center justify-between bg-white p-[15px] backdrop-blur-xl',
+          'fixed top-0 z-10 flex w-full items-center justify-between bg-white/60 p-[15px] backdrop-blur-xl',
           MOBILE_MAX_WIDTH,
           FORM_HEADER_HEIGHT_CLASS
         )}

--- a/src/pages/rules/components/RuleForm.tsx
+++ b/src/pages/rules/components/RuleForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/pages/rules/hooks/useRuleFormModel';
 import type { CreateRuleRequest } from '@/api/rule/rule.types';
 import { formatKoreanTime } from '@/utils/ruleForm';
+import AppButton from '@/components/common/AppButton';
 
 type RuleFormProps = {
   mode: RuleFormMode;
@@ -149,13 +150,12 @@ const RuleForm = ({
           </section>
 
           {mode === 'edit' && (
-            <button
-              type="button"
+            <AppButton
               onClick={onDelete}
-              className="h-12 w-full rounded-[12px] bg-red-500 text-base font-semibold text-white"
+              className="bg-red-500 text-base font-semibold text-white"
             >
               규칙 삭제
-            </button>
+            </AppButton>
           )}
         </section>
       </div>

--- a/src/pages/todos/TodoEditPage.tsx
+++ b/src/pages/todos/TodoEditPage.tsx
@@ -1,4 +1,4 @@
-import type { TodoFormValues, TodoWithLocal } from '@/types/todo';
+﻿import type { TodoFormValues, TodoWithLocal } from '@/types/todo';
 import {
   createDefaultRepeatValue,
   toTodoRequestPayload,
@@ -41,8 +41,18 @@ const TodoEditPage = () => {
     navigate(-1);
   };
 
+  const handleDelete = () => {
+    console.log('할 일 삭제:', todo.id);
+    navigate(-1);
+  };
+
   return (
-    <TodoForm mode="edit" initialValues={initialValues} onSubmit={handleEdit} />
+    <TodoForm
+      mode="edit"
+      initialValues={initialValues}
+      onSubmit={handleEdit}
+      onDelete={handleDelete}
+    />
   );
 };
 

--- a/src/pages/todos/components/TodoForm.tsx
+++ b/src/pages/todos/components/TodoForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/schemas/todoCreateSchema';
 
 import AppButton from '@/components/common/AppButton';
+import AppDialog from '@/components/common/AppDialog';
 import DateWheelDialog from '@/pages/todos/components/DateWheelDialog';
 import FormPageLayout from '@/components/form/FormPageLayout';
 import RandomAssignOverlay from '@/pages/todos/components/RandomAssignOverlay';
@@ -16,6 +17,7 @@ import type { TodoFormValues } from '@/types/todo';
 import { cn } from '@/lib/utils';
 import { formatDate } from '@/utils/date';
 import { mockMembers } from '@/mocks/mockData';
+import { useState } from 'react';
 import { useTodoFormModel } from '@/pages/todos/hooks/useTodoFormModel';
 
 type TodoFormMode = 'create' | 'edit';
@@ -24,10 +26,17 @@ type TodoFormProps = {
   mode: TodoFormMode;
   initialValues?: Partial<TodoFormValues>;
   onSubmit: (values: TodoFormValues) => void;
+  onDelete?: () => void;
 };
 
-const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
+const TodoForm = ({
+  mode,
+  initialValues,
+  onSubmit,
+  onDelete,
+}: TodoFormProps) => {
   const model = useTodoFormModel({ initialValues, onSubmit });
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   return (
     <FormPageLayout
@@ -159,7 +168,7 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
 
           {mode === 'edit' && (
             <AppButton
-              onClick={() => {}}
+              onClick={() => setIsDeleteDialogOpen(true)}
               className="bg-red-500 text-base font-semibold text-white"
             >
               할 일 삭제
@@ -186,6 +195,38 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
           onConfirm={model.actions.handleConfirmRandomAssignee}
         />
       )}
+
+      <AppDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title="할 일 삭제 확인"
+        contentClassName="w-[300px] p-4 pt-8 pb-4"
+      >
+        <div className="flex flex-col items-center gap-10">
+          <h2 className="text-center text-base font-semibold text-black">
+            할 일을 삭제하시겠습니까?
+          </h2>
+
+          <div className="flex w-full items-center justify-between">
+            <AppButton
+              onClick={() => setIsDeleteDialogOpen(false)}
+              className="w-32 border border-zinc-800 text-zinc-800"
+            >
+              취소
+            </AppButton>
+
+            <AppButton
+              onClick={() => {
+                setIsDeleteDialogOpen(false);
+                onDelete?.();
+              }}
+              className="w-32 bg-zinc-800 text-zinc-100"
+            >
+              확인
+            </AppButton>
+          </div>
+        </div>
+      </AppDialog>
     </FormPageLayout>
   );
 };

--- a/src/pages/todos/components/TodoForm.tsx
+++ b/src/pages/todos/components/TodoForm.tsx
@@ -2,19 +2,20 @@
   ControlledEditableInputSection,
   ControlledTextareaSection,
 } from '@/components/form/ControlledTextSections';
-import FormPageLayout from '@/components/form/FormPageLayout';
-import AppButton from '@/components/common/AppButton';
-import DateWheelDialog from '@/pages/todos/components/DateWheelDialog';
-import RandomAssignOverlay from '@/pages/todos/components/RandomAssignOverlay';
-import RepeatSection from '@/pages/todos/components/RepeatSection';
-import { mockMembers } from '@/mocks/mockData';
 import {
   TODO_MEMO_MAX_LENGTH,
   TODO_TITLE_MAX_LENGTH,
 } from '@/schemas/todoCreateSchema';
+
+import AppButton from '@/components/common/AppButton';
+import DateWheelDialog from '@/pages/todos/components/DateWheelDialog';
+import FormPageLayout from '@/components/form/FormPageLayout';
+import RandomAssignOverlay from '@/pages/todos/components/RandomAssignOverlay';
+import RepeatSection from '@/pages/todos/components/RepeatSection';
 import type { TodoFormValues } from '@/types/todo';
 import { cn } from '@/lib/utils';
 import { formatDate } from '@/utils/date';
+import { mockMembers } from '@/mocks/mockData';
 import { useTodoFormModel } from '@/pages/todos/hooks/useTodoFormModel';
 
 type TodoFormMode = 'create' | 'edit';
@@ -38,113 +39,128 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
       onSubmit={model.form.submitForm}
       submitDisabled={!model.form.isValid}
     >
-      <ControlledEditableInputSection
-        control={model.form.control}
-        name="title"
-        id="todo-title"
-        placeholder="할 일을 입력하세요"
-        maxLength={TODO_TITLE_MAX_LENGTH}
-        className="px-4"
-      />
-
-      <div className="mt-[26px] mb-[30px] h-3 bg-neutral-100" />
-
-      <div className="px-4">
-        <p className="text-sm font-semibold text-[#BCBCBC]">상세 설정</p>
-
-        <div className="flex flex-col gap-[30px] pt-6">
-          <section className="space-y-4">
-            <p className="text-base font-semibold">마감기한</p>
-
-            <div>
-              <AppButton
-                disabled={model.state.repeatValue.enabled}
-                onClick={() => {
-                  if (model.state.repeatValue.enabled) return;
-                  model.actions.setIsDueDateDialogOpen(true);
-                }}
-                className="text-muted-foreground bg-secondary border-border border text-lg font-semibold"
-              >
-                {model.state.dueDate
-                  ? `${formatDate(model.state.dueDate)} 까지`
-                  : '마감기한 선택'}
-              </AppButton>
-
-              {model.state.repeatValue.enabled && (
-                <p className="text-destructive/50 pt-2 text-xs font-medium">
-                  반복 설정 시 마감기한은 설정할 수 없어요.
-                </p>
-              )}
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <p className="text-base font-semibold">담당자</p>
-
-            <div className="flex flex-col gap-[10px]">
-              <div className="grid grid-cols-4 gap-[10px]">
-                {mockMembers.map((member) => {
-                  const isSelected = model.state.selectedAssigneeId === member.id;
-                  const isRandomAssigned =
-                    model.state.randomAssignedAssigneeId === member.id;
-
-                  return (
-                    <button
-                      key={member.id}
-                      type="button"
-                      onClick={() => model.actions.handleSelectAssignee(member.id)}
-                      className={cn(
-                        'rounded-full border px-4 py-2 text-base font-semibold transition-colors',
-                        isSelected && isRandomAssigned
-                          ? 'from-primary border-none bg-gradient-to-r to-zinc-500 text-white'
-                          : isSelected
-                            ? 'border-border bg-primary text-white'
-                            : 'border-border hover:bg-secondary'
-                      )}
-                    >
-                      {member.name}
-                    </button>
-                  );
-                })}
-              </div>
-
-              {mode === 'create' && (
-                <AppButton
-                  onClick={model.actions.handleRandomAssign}
-                  disabled={model.state.isRandomAssigneeLocked}
-                  className="text-primary-foreground from-primary bg-gradient-to-r to-zinc-500 text-sm font-medium"
-                >
-                  랜덤으로 맡기기
-                </AppButton>
-              )}
-
-              {model.state.isRandomAssigneeLocked && mode === 'create' && (
-                <p className="text-destructive/50 pt-2 text-xs font-medium">
-                  랜덤 배정 시 반복 설정은 사용할 수 없어요.
-                </p>
-              )}
-            </div>
-          </section>
-
-          <RepeatSection
-            value={model.state.repeatValue}
-            onChange={model.actions.setRepeatValue}
-            disabled={model.state.isRandomAssigneeLocked}
+      <div className="bg-zinc-100 pb-6">
+        <div className="bg-white/60 px-[15px] pt-[15px] pb-[30px] backdrop-blur-xl">
+          <ControlledEditableInputSection
+            control={model.form.control}
+            name="title"
+            id="todo-title"
+            placeholder="할 일을 입력하세요"
+            maxLength={TODO_TITLE_MAX_LENGTH}
           />
+        </div>
 
-          <section className="space-y-4">
-            <p className="text-base font-semibold">메모</p>
+        <div className="flex flex-col gap-6 px-[15px] pt-6">
+          <section className="flex flex-col gap-3">
+            <h2 className="text-sm font-semibold text-zinc-400">기본 설정</h2>
 
-            <ControlledTextareaSection
-              control={model.form.control}
-              name="memo"
-              id="todo-memo"
-              placeholder="메모를 입력하세요"
-              maxLength={TODO_MEMO_MAX_LENGTH}
-              containerClassName="flex flex-col gap-1"
-              textareaClassName="border-border bg-secondary rounded-[10px] px-4 py-2 text-sm font-medium placeholder:font-medium placeholder:text-neutral-400 focus:border-neutral-900"
-              counterClassName="text-xs font-semibold text-[#BCBCBC]"
-            />
+            <div className="flex flex-col gap-2">
+              <section className="flex flex-col gap-4 rounded-[20px] border border-zinc-100 bg-white p-4">
+                <p className="text-base font-semibold">마감기한</p>
+
+                <div className="flex flex-col gap-2">
+                  <AppButton
+                    disabled={model.state.repeatValue.enabled}
+                    onClick={() => {
+                      if (model.state.repeatValue.enabled) return;
+                      model.actions.setIsDueDateDialogOpen(true);
+                    }}
+                    className="bg-zinc-100 text-zinc-300 border-zinc-200 border text-lg font-semibold"
+                  >
+                    {model.state.dueDate
+                      ? `${formatDate(model.state.dueDate)} 까지`
+                      : '마감기한 선택'}
+                  </AppButton>
+
+                  <p className="text-right text-xs font-medium text-zinc-400">
+                    반복 설정 시 선택한 요일에 맞춰 마감기한이 자동 지정됩니다.
+                  </p>
+                </div>
+              </section>
+
+              <section className="flex flex-col gap-4 rounded-[20px] border border-zinc-100 bg-white p-4">
+                <p className="text-base font-semibold">담당자</p>
+
+                <div className="flex flex-col gap-[10px]">
+                  <div className="grid grid-cols-3 gap-2">
+                    {mockMembers.map((member) => {
+                      const isSelected =
+                        model.state.selectedAssigneeId === member.id;
+                      const isRandomAssigned =
+                        model.state.randomAssignedAssigneeId === member.id;
+
+                      return (
+                        <button
+                          key={member.id}
+                          type="button"
+                          onClick={() =>
+                            model.actions.handleSelectAssignee(member.id)
+                          }
+                          title={member.name}
+                          className={cn(
+                            'h-10 min-w-0 rounded-[12px] border px-3 py-2 text-sm font-semibold transition-colors',
+                            isSelected && isRandomAssigned
+                              ? 'from-primary border-none bg-gradient-to-r to-zinc-500 text-white'
+                              : isSelected
+                                ? 'border-zinc-900 bg-zinc-800 text-zinc-100'
+                                : 'border-zinc-100 bg-zinc-50 text-zinc-500 hover:bg-zinc-100'
+                          )}
+                        >
+                          <span className="block w-full truncate whitespace-nowrap">
+                            {member.name}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {mode === 'create' && (
+                    <AppButton
+                      onClick={model.actions.handleRandomAssign}
+                      disabled={model.state.isRandomAssigneeLocked}
+                      className="from-primary bg-gradient-to-r to-zinc-500 text-sm font-medium text-white"
+                    >
+                      운명에 맡기기
+                    </AppButton>
+                  )}
+
+                  {model.state.isRandomAssigneeLocked && mode === 'create' && (
+                    <p className="text-destructive/50 text-xs font-medium">
+                      랜덤 배정 시 반복 설정은 사용할 수 없어요.
+                    </p>
+                  )}
+                </div>
+              </section>
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-3">
+            <h2 className="text-sm font-semibold text-zinc-400">추가 설정</h2>
+
+            <div className="flex flex-col gap-2">
+              <section className="rounded-[20px] bg-white p-4">
+                <RepeatSection
+                  value={model.state.repeatValue}
+                  onChange={model.actions.setRepeatValue}
+                  disabled={model.state.isRandomAssigneeLocked}
+                />
+              </section>
+
+              <section className="flex flex-col gap-4 rounded-[20px] bg-white p-4">
+                <p className="text-base font-semibold">메모</p>
+
+                <ControlledTextareaSection
+                  control={model.form.control}
+                  name="memo"
+                  id="todo-memo"
+                  placeholder="메모를 입력하세요"
+                  maxLength={TODO_MEMO_MAX_LENGTH}
+                  containerClassName="flex flex-col gap-2"
+                  textareaClassName="rounded-[20px] border-zinc-200 bg-zinc-100 p-4 text-sm font-semibold placeholder:text-zinc-300 focus:border-zinc-600"
+                  counterClassName="text-xs font-medium text-zinc-400"
+                />
+              </section>
+            </div>
           </section>
         </div>
       </div>
@@ -172,4 +188,3 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
 };
 
 export default TodoForm;
-

--- a/src/pages/todos/components/TodoForm.tsx
+++ b/src/pages/todos/components/TodoForm.tsx
@@ -27,15 +27,11 @@ type TodoFormProps = {
 };
 
 const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
-  const model = useTodoFormModel({
-    mode,
-    initialValues,
-    onSubmit,
-  });
+  const model = useTodoFormModel({ initialValues, onSubmit });
 
   return (
     <FormPageLayout
-      title={mode === 'create' ? '할 일 등록' : '할 일 수정'}
+      title={mode === 'create' ? '할 일 등록' : '할 일 편집'}
       onSubmit={model.form.submitForm}
       submitDisabled={!model.form.isValid}
     >
@@ -65,7 +61,7 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
                       if (model.state.repeatValue.enabled) return;
                       model.actions.setIsDueDateDialogOpen(true);
                     }}
-                    className="bg-zinc-100 text-zinc-300 border-zinc-200 border text-lg font-semibold"
+                    className="border border-zinc-200 bg-zinc-100 text-lg font-semibold text-zinc-300"
                   >
                     {model.state.dueDate
                       ? `${formatDate(model.state.dueDate)} 까지`
@@ -114,17 +110,15 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
                     })}
                   </div>
 
-                  {mode === 'create' && (
-                    <AppButton
-                      onClick={model.actions.handleRandomAssign}
-                      disabled={model.state.isRandomAssigneeLocked}
-                      className="from-primary bg-gradient-to-r to-zinc-500 text-sm font-medium text-white"
-                    >
-                      운명에 맡기기
-                    </AppButton>
-                  )}
+                  <AppButton
+                    onClick={model.actions.handleRandomAssign}
+                    disabled={model.state.isRandomAssigneeLocked}
+                    className="from-primary bg-gradient-to-r to-zinc-500 text-sm font-medium text-white"
+                  >
+                    운명에 맡기기
+                  </AppButton>
 
-                  {model.state.isRandomAssigneeLocked && mode === 'create' && (
+                  {model.state.isRandomAssigneeLocked && (
                     <p className="text-destructive/50 text-xs font-medium">
                       랜덤 배정 시 반복 설정은 사용할 수 없어요.
                     </p>
@@ -162,6 +156,15 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
               </section>
             </div>
           </section>
+
+          {mode === 'edit' && (
+            <AppButton
+              onClick={() => {}}
+              className="bg-red-500 text-base font-semibold text-white"
+            >
+              할 일 삭제
+            </AppButton>
+          )}
         </div>
       </div>
 
@@ -175,7 +178,7 @@ const TodoForm = ({ mode, initialValues, onSubmit }: TodoFormProps) => {
         }}
       />
 
-      {model.state.randomAssignStage !== 'idle' && mode === 'create' && (
+      {model.state.randomAssignStage !== 'idle' && (
         <RandomAssignOverlay
           stage={model.state.randomAssignStage}
           candidateName={model.state.randomCandidate?.name}

--- a/src/pages/todos/hooks/useTodoFormModel.ts
+++ b/src/pages/todos/hooks/useTodoFormModel.ts
@@ -1,4 +1,4 @@
-import { mockMembers } from '@/mocks/mockData';
+﻿import { mockMembers } from '@/mocks/mockData';
 import {
   todoCreateSchema,
   type TodoCreateValues,
@@ -9,17 +9,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-type TodoFormMode = 'create' | 'edit';
 type RandomAssignStage = 'idle' | 'loading' | 'result';
 
 type UseTodoFormModelParams = {
-  mode: TodoFormMode;
   initialValues?: Partial<TodoFormValues>;
   onSubmit: (values: TodoFormValues) => void;
 };
 
 export const useTodoFormModel = ({
-  mode,
   initialValues,
   onSubmit,
 }: UseTodoFormModelParams) => {
@@ -70,8 +67,7 @@ export const useTodoFormModel = ({
   }, []);
 
   const handleRandomAssign = () => {
-    // 편집 화면에서는 랜덤 배정 사용하지 않음
-    if (mode === 'edit' || isRandomAssigneeLocked) return;
+    if (isRandomAssigneeLocked) return;
 
     if (randomAssignTimeoutRef.current) {
       window.clearTimeout(randomAssignTimeoutRef.current);


### PR DESCRIPTION
## PR 개요
- 할 일 등록 및 편집 화면을 최종 디자인 기준으로 개선하고, 폼 구조 정리
- 편집 기능 확장 및 삭제 플로우 추가

## 변경 사항
### 1. 할 일 등록 폼 UI 개선
- `TodoForm`을 기본/추가 설정 카드형 레이아웃으로 정리
- 상단 입력 영역 간격 및 타이포 피그마 기준으로 조정
- 담당자 선택 UI를 3열 그리드 + 이름 `truncate`로 개선
- 랜덤 배정 버튼 문구를 ‘운명에 맡기기’로 변경
- `FormPageLayout` 헤더 `z-index` 보정으로 스크롤 시 가림 문제 수정

### 2. 편집 화면 기능 확장 및 구조 정리
- 편집 모드에서도 ‘운명에 맡기기’ 버튼 및 오버레이 동작 지원
- `useTodoFormModel`에서 `mode` 의존 제거 및 로직 단순화
- 편집 화면 타이틀을 ‘할 일 편집’으로 수정
- 삭제 버튼 영역 추가 및 버튼 컴포넌트(`AppButton`)로 통일

### 3. 삭제 플로우 및 확인 다이얼로그 추가
- 편집 화면에서 삭제 버튼 클릭 시 확인 다이얼로그(`AppDialog`) 표시
- 확인/취소 버튼을 디자인 스펙에 맞게 구성
- `TodoForm`에 `onDelete` prop 추가 및 삭제 핸들러 연결
- `TodoEditPage`와 연동하여 실제 삭제 흐름 구현

## 스크린샷 (선택)
### 🧩 할 일 등록/편집 화면
| 할 일 등록 화면 | 할 일 편집 화면 |
|------------|------------|
| ![TodoCreatePage](https://github.com/user-attachments/assets/d28137cd-4e56-46ca-9146-449657f6bcae) | ![TodoEditPage](https://github.com/user-attachments/assets/f2e132da-7cde-4e1d-aa2a-c9c881f15fa8) |

## 추후 할 일
- #39 

## Related Issue
- Closes #38 
