### PR TITLE
[feat] 할 일 상세보기 최종 디자인 반영

### DIFF
--- a/src/pages/rules/components/RuleDetailSheet.tsx
+++ b/src/pages/rules/components/RuleDetailSheet.tsx
@@ -84,7 +84,7 @@ const RuleDetailSheet = ({
               },
             });
           }}
-          className="text-[#A3A3A3]"
+          className="text-zinc-400"
         >
           <PencilLine className="h-6 w-6 transition-colors hover:text-black" />
         </button>

--- a/src/pages/todos/components/TodoDetailSheet.tsx
+++ b/src/pages/todos/components/TodoDetailSheet.tsx
@@ -1,13 +1,13 @@
-import { PencilLine, Trash2 } from 'lucide-react';
-import {
+﻿import {
   getTodoDetailViewState,
   getTodoStatusLabel,
   getTodoStatusSubLabel,
 } from '@/utils/todos';
 
+import AppButton from '@/components/common/AppButton';
 import BottomSheet from '@/components/common/BottomSheet';
-import { Button } from '@/components/ui/button';
 import { MOCK_TODAY } from '@/mocks/mockData';
+import { PencilLine } from 'lucide-react';
 import type { ReactNode } from 'react';
 import type { TodoWithLocal } from '@/types/todo';
 import UserAvatar from '@/components/common/UserAvatar';
@@ -57,147 +57,111 @@ const TodoDetailSheet = ({
     <BottomSheet
       open={open}
       onOpenChange={onOpenChange}
-      className="rounded-t-[24px] pb-[30px] [&>div:first-child]:my-2 [&>div:first-child]:h-[5px] [&>div:first-child]:w-20 [&>div:first-child]:bg-[#CECECE]"
+      className="rounded-t-[24px] [&>div:first-child]:my-2.5 [&>div:first-child]:h-[5px] [&>div:first-child]:w-20 [&>div:first-child]:bg-zinc-400"
     >
-      <div className="px-[15px] pt-5">
-        <div className="flex flex-col pt-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-black">
-              {todo?.title ?? '-'}
-            </h2>
+      <div className="flex items-center justify-between px-5 pt-8 pb-[15px]">
+        <h2 className="text-xl font-semibold text-black">
+          {todo?.title ?? '-'}
+        </h2>
 
-            {viewState?.canEdit && (
-              <button
-                type="button"
-                onClick={() => {
-                  navigate(`/todos/${todo?.id}/edit`, { state: { todo } });
-                }}
-                className="text-[#A3A3A3]"
-              >
-                <PencilLine className="h-6 w-6" />
-              </button>
-            )}
-          </div>
+        {viewState?.canEdit && (
+          <button
+            type="button"
+            onClick={() => {
+              navigate(`/todos/${todo?.id}/edit`, { state: { todo } });
+            }}
+            className="text-zinc-400"
+          >
+            <PencilLine className="h-6 w-6 transition-colors hover:text-black" />
+          </button>
+        )}
+      </div>
 
-          <div className="flex flex-col gap-8 pt-[52px]">
-            <DetailRow
-              label="마감일"
-              value={todo ? formatDueDateLabel(todo.dueAt) : '-'}
-            />
+      {/* 스크롤 영역 */}
+      <div className="min-h-0 flex-1 gap-8 overflow-y-auto p-5">
+        <div className="flex flex-col gap-6">
+          <DetailRow
+            label="마감일"
+            value={todo ? formatDueDateLabel(todo.dueAt) : '-'}
+          />
 
-            <DetailRow
-              label="담당자"
-              value={
-                <span className="inline-flex items-center gap-1">
-                  <UserAvatar
-                    size="sm"
-                    src={assigneeImage}
-                    alt={assigneeName}
-                  />
-                  <span>{assigneeName ?? '-'}</span>
-                </span>
-              }
-            />
+          <DetailRow
+            label="담당자"
+            value={
+              <span className="inline-flex items-center gap-1">
+                <UserAvatar size="sm" src={assigneeImage} alt={assigneeName} />
+                <span>{assigneeName ?? '-'}</span>
+              </span>
+            }
+          />
 
-            <DetailRow label="반복" value="반복 없음" />
+          <DetailRow label="반복" value="반복 없음" />
 
-            <DetailRow
-              label="메모"
-              value={
-                todo?.memo ? (
-                  <span className="break-keep">{todo.memo}</span>
-                ) : (
-                  '-'
-                )
-              }
-              alignTop
-            />
+          <DetailRow
+            label="메모"
+            value={
+              todo?.memo ? <span className="break-keep">{todo.memo}</span> : '-'
+            }
+            alignTop
+          />
 
-            <DetailRow
-              label="상태"
-              value={
-                <div className="flex flex-col items-end gap-1">
-                  <span>
-                    {todo ? getTodoStatusLabel(todo, MOCK_TODAY) : '-'}
+          <DetailRow
+            label="상태"
+            value={
+              <div className="flex flex-col items-end gap-1">
+                <span>{todo ? getTodoStatusLabel(todo, MOCK_TODAY) : '-'}</span>
+
+                {todo && (
+                  <span className="text-zinc-300">
+                    {getTodoStatusSubLabel(todo, MOCK_TODAY)}
                   </span>
+                )}
+              </div>
+            }
+            alignTop
+          />
 
-                  {todo && (
-                    <span className="text-[#ACACAC]">
-                      {getTodoStatusSubLabel(todo, MOCK_TODAY)}
-                    </span>
-                  )}
-                </div>
-              }
-              alignTop
-            />
-
-            {/* 인증 사진 */}
-            {viewState?.isCompleted && todo?.proofImageUrl && (
-              <div className="bg-accent h-[180px] w-full rounded-xl" />
-            )}
-          </div>
-
-          {/* 하단 버튼 */}
-          <div className="flex items-center justify-between gap-1 pt-[26px]">
-            {viewState?.canDelete && (
-              <button
-                type="button"
-                className="flex h-12 w-12 items-center justify-center rounded-[10px] bg-[#D9D9D9] text-[#737373]"
-              >
-                <Trash2 className="h-5 w-5" />
-              </button>
-            )}
-
-            <div className="flex flex-1 items-center gap-1">
-              {!viewState?.isCompleted && (
-                <>
-                  {viewState?.canConfirmComplete && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="border-primary h-12 flex-1 rounded-[10px] px-4 text-sm"
-                    >
-                      확인으로 완료
-                    </Button>
-                  )}
-
-                  {viewState?.canPhotoComplete && (
-                    <Button
-                      type="button"
-                      className="h-12 flex-1 rounded-[10px] px-4 text-sm"
-                    >
-                      사진인증해서 완료
-                    </Button>
-                  )}
-                </>
-              )}
-
-              {viewState?.isCompleted && (
-                <>
-                  {viewState?.canRevertToInProgress && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="border-primary h-12 flex-1 rounded-[10px] px-4 text-sm"
-                    >
-                      진행중으로 변경
-                    </Button>
-                  )}
-
-                  {viewState?.canAddProofImage && (
-                    <Button
-                      type="button"
-                      className="h-12 flex-1 rounded-[10px] px-4 text-sm"
-                    >
-                      인증 사진 추가하기
-                    </Button>
-                  )}
-                </>
-              )}
+          {/* 인증 사진 */}
+          {viewState?.isCompleted && todo?.proofImageUrl && (
+            <div className="flex justify-end">
+              <div className="h-37.5 w-50 rounded-[20px] bg-zinc-200" />
             </div>
-          </div>
+          )}
         </div>
       </div>
+
+      {/* 하단 버튼 */}
+      {viewState?.isMine && (
+        <div className="flex items-center justify-between gap-1 p-5">
+          <div className="flex flex-1 items-center gap-1">
+            {!viewState.isCompleted && viewState.canConfirmComplete && (
+              <AppButton className="flex-1 bg-black text-white">
+                완료하기
+              </AppButton>
+            )}
+
+            {viewState.isCompleted && viewState.canRevertToInProgress && (
+              <AppButton
+                className={`flex-1 ${
+                  viewState.hasProofImage
+                    ? 'bg-black text-white'
+                    : 'border border-zinc-400'
+                }`}
+              >
+                진행 중으로 변경
+              </AppButton>
+            )}
+
+            {viewState.isCompleted &&
+              !viewState.hasProofImage &&
+              viewState.canAddProofImage && (
+                <AppButton className="flex-1 bg-black text-white">
+                  인증 사진 추가
+                </AppButton>
+              )}
+          </div>
+        </div>
+      )}
     </BottomSheet>
   );
 };

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -21,7 +21,7 @@ export type TodoWithLocal = Todo & {
   };
 };
 
-export type TodoStatusLabel = '진행' | '지연' | '완료' | '지연 완료';
+export type TodoStatusLabel = '진행중' | '지연' | '완료' | '지연 완료';
 
 export type TodoDetailViewState = {
   isMine: boolean;

--- a/src/utils/todos.ts
+++ b/src/utils/todos.ts
@@ -67,7 +67,7 @@ export const getTodoStatusLabel = (
     return delayed ? '지연 완료' : '완료';
   }
 
-  return delayed ? '지연' : '진행';
+  return delayed ? '지연' : '진행중';
 };
 
 // 상태 하단 라벨
@@ -86,7 +86,7 @@ export const getTodoStatusSubLabel = (todo: TodoWithLocal, today: string) => {
     return formatStatusDateLabel(todo.completedAt);
   }
 
-  return formatStatusDateLabel(todo.dueAt);
+  return;
 };
 
 // 상세 보기용 상태


### PR DESCRIPTION
## PR 개요
- 할 일 상세보기 화면을 최종 디자인 기준으로 개선하고, 상태에 따른 하단 액션 버튼 정책 재구성
- 상세 시트 레이아웃 및 상태 표현을 정리해 사용자 인터랙션 개선

## 변경 사항
### 1. 상세 시트 레이아웃 개선
- `TodoDetailSheet` 본문 영역을 스크롤 가능하도록 구조 개선
- 콘텐츠 영역과 하단 액션 영역 분리로 레이아웃 안정성 확보

### 2. 하단 액션 버튼 정책 재구성
- 할 일 상태 및 조건에 따라 버튼 노출/구성 로직 정리
    - 미완료: 완료하기
    - 완료(사진 없음): 진행 중으로 변경, 인증 사진 추가
    - 완료(사진 있음): 진행 중으로 변경 (단독 노출 시 primary 스타일)
    - 타인 할 일: 버튼 미노출
- 상태 기반 인터랙션 흐름 정리

### 3. 공통 컴포넌트 및 상태 표현 정리
- 상세 시트 버튼을 `AppButton`으로 통일
- todo 상태 라벨을 `진행 → 진행중`으로 정리
- 관련 타입 및 유틸 로직 반영

## 스크린샷 (선택)
### 🧩 TodoDetail
| 할 일 상세보기 |
|----|
| ![TodoDetail](https://github.com/user-attachments/assets/b6e64e3d-5e14-4a79-8ee2-12b5deb97790) |

## 추후 할 일
- #40 

## Related Issue
Closes #39 
