### PR TITLE
[feat] 할 일 완료 화면 최종 디자인 반영

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -31,8 +31,9 @@ const BottomSheet = ({
     <Drawer open={open} onOpenChange={onOpenChange} dismissible={dismissible}>
       <DrawerContent
         className={cn(
-          'mx-auto max-h-[70dvh] w-full rounded-t-[16px]',
+          'mx-auto max-h-[70dvh] w-full rounded-t-[24px]',
           !dismissible && '[&>div:first-child]:hidden',
+          '[&>div:first-child]:my-2.5 [&>div:first-child]:h-[5px] [&>div:first-child]:w-20 [&>div:first-child]:bg-zinc-400',
           className,
           MOBILE_MAX_WIDTH
         )}

--- a/src/pages/rules/components/RuleDetailSheet.tsx
+++ b/src/pages/rules/components/RuleDetailSheet.tsx
@@ -60,11 +60,7 @@ const RuleDetailSheet = ({
   );
 
   return (
-    <BottomSheet
-      open={open}
-      onOpenChange={onOpenChange}
-      className="min-h-[442px] rounded-t-[24px] [&>div:first-child]:my-[10px] [&>div:first-child]:h-[5px] [&>div:first-child]:w-20 [&>div:first-child]:rounded-[5px] [&>div:first-child]:bg-zinc-400"
-    >
+    <BottomSheet open={open} onOpenChange={onOpenChange}>
       <div className="flex items-center justify-between px-5 pt-8 pb-[15px]">
         <h2 className="text-xl font-semibold text-black">
           {isLoading ? '불러오는 중...' : (rule?.title ?? '-')}

--- a/src/pages/todos/components/TodoCompleteSheet.tsx
+++ b/src/pages/todos/components/TodoCompleteSheet.tsx
@@ -1,4 +1,4 @@
-import { Camera, ImagePlus, Images } from 'lucide-react';
+import { Camera, ImagePlus, Images, Minus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import AppButton from '@/components/common/AppButton';
@@ -82,7 +82,7 @@ const TodoCompleteSheet = ({
       </div>
 
       <div className="px-5">
-        <div className="flex h-50 items-center justify-center overflow-hidden rounded-[24px] bg-zinc-200">
+        <div className="relative flex h-50 items-center justify-center overflow-hidden rounded-[24px] bg-zinc-200">
           {previewUrl ? (
             <img
               src={previewUrl}
@@ -99,6 +99,20 @@ const TodoCompleteSheet = ({
                 JPG((jpeg)), PNG, webp 파일만 가능 (최대 10MB)
               </p>
             </div>
+          )}
+
+          {previewUrl && (
+            <button
+              type="button"
+              aria-label="첨부한 사진 제거"
+              onClick={() => {
+                setSelectedFile(undefined);
+                setErrorMessage('');
+              }}
+              className="absolute top-[15px] right-[14px] flex size-6 items-center justify-center rounded-[12px] bg-zinc-100 shadow-[0px_1px_6px_0px_rgba(0,0,0,0.25)]"
+            >
+              <Minus className="h-4 w-4 text-zinc-600" />
+            </button>
           )}
         </div>
 
@@ -138,7 +152,7 @@ const TodoCompleteSheet = ({
           className="bg-black text-white"
           onClick={() => onConfirmComplete?.(selectedFile)}
         >
-          완료 하기
+          {selectedFile ? '등록 하기' : '완료 하기'}
         </AppButton>
       </div>
 

--- a/src/pages/todos/components/TodoCompleteSheet.tsx
+++ b/src/pages/todos/components/TodoCompleteSheet.tsx
@@ -1,0 +1,165 @@
+import { Camera, ImagePlus, Images } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import AppButton from '@/components/common/AppButton';
+import BottomSheet from '@/components/common/BottomSheet';
+
+type TodoCompleteSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirmComplete?: (proofImageFile?: File) => void;
+};
+
+const IMAGE_ACCEPT = 'image/jpeg,image/png,image/webp';
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+const TodoCompleteSheet = ({
+  open,
+  onOpenChange,
+  onConfirmComplete,
+}: TodoCompleteSheetProps) => {
+  const cameraInputRef = useRef<HTMLInputElement | null>(null);
+  const galleryInputRef = useRef<HTMLInputElement | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File>();
+  const [previewUrl, setPreviewUrl] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSelectImage = (file?: File) => {
+    if (!file) return;
+
+    const isValidType = ['image/jpeg', 'image/png', 'image/webp'].includes(
+      file.type
+    );
+
+    if (!isValidType) {
+      setErrorMessage('JPG, PNG, webp 파일만 첨부할 수 있어요.');
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setErrorMessage('이미지 용량은 최대 10MB까지 첨부할 수 있어요.');
+      return;
+    }
+
+    setErrorMessage('');
+    setSelectedFile(file);
+  };
+
+  useEffect(() => {
+    if (!selectedFile) {
+      setPreviewUrl(undefined);
+      return;
+    }
+
+    const nextPreviewUrl = URL.createObjectURL(selectedFile);
+    setPreviewUrl(nextPreviewUrl);
+
+    return () => URL.revokeObjectURL(nextPreviewUrl);
+  }, [selectedFile]);
+
+  useEffect(() => {
+    if (open) return;
+
+    setSelectedFile(undefined);
+    setPreviewUrl(undefined);
+    setErrorMessage('');
+  }, [open]);
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title="할 일 완료하기"
+      description="사진 첨부 후 할 일을 완료할 수 있는 바텀시트"
+    >
+      <div className="px-5 pt-8 pb-[15px]">
+        <h2 className="text-lg leading-[1.3] font-semibold text-black">
+          완료방법을 선택해주세요 !
+        </h2>
+        <p className="mt-[5px] text-xs leading-[1.3] font-semibold text-zinc-400">
+          사진을 등록하지않으면 바로 완료됩니다 .
+        </p>
+      </div>
+
+      <div className="px-5">
+        <div className="flex h-50 items-center justify-center overflow-hidden rounded-[24px] bg-zinc-200">
+          {previewUrl ? (
+            <img
+              src={previewUrl}
+              alt="인증 사진 미리보기"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex flex-col items-center">
+              <ImagePlus className="h-10 w-10 text-zinc-300" />
+              <p className="mt-2 text-center text-xs leading-[1.3] font-semibold text-zinc-600">
+                인증샷 한 장으로 완벽하게 마무리해보세요.
+              </p>
+              <p className="mt-1 text-center text-[10px] leading-[1.3] font-medium text-zinc-500">
+                JPG((jpeg)), PNG, webp 파일만 가능 (최대 10MB)
+              </p>
+            </div>
+          )}
+        </div>
+
+        {errorMessage && (
+          <p className="mt-2 text-xs font-medium text-red-500">
+            {errorMessage}
+          </p>
+        )}
+      </div>
+
+      <div className="px-5 pt-[15px]">
+        <div className="flex items-center gap-1">
+          <AppButton
+            className="flex-1 border border-zinc-400 bg-white text-zinc-800"
+            onClick={() => cameraInputRef.current?.click()}
+          >
+            <span className="flex items-center justify-center gap-2">
+              <Camera className="h-[17px] w-[17px]" />
+              <span>카메라</span>
+            </span>
+          </AppButton>
+
+          <AppButton
+            className="flex-1 border border-zinc-400 bg-white text-zinc-800"
+            onClick={() => galleryInputRef.current?.click()}
+          >
+            <span className="flex items-center justify-center gap-2">
+              <Images className="h-[17px] w-[17px]" />
+              <span>갤러리</span>
+            </span>
+          </AppButton>
+        </div>
+      </div>
+
+      <div className="p-5">
+        <AppButton
+          className="bg-black text-white"
+          onClick={() => onConfirmComplete?.(selectedFile)}
+        >
+          완료 하기
+        </AppButton>
+      </div>
+
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept={IMAGE_ACCEPT}
+        capture="environment"
+        className="hidden"
+        onChange={(event) => handleSelectImage(event.target.files?.[0])}
+      />
+
+      <input
+        ref={galleryInputRef}
+        type="file"
+        accept={IMAGE_ACCEPT}
+        className="hidden"
+        onChange={(event) => handleSelectImage(event.target.files?.[0])}
+      />
+    </BottomSheet>
+  );
+};
+
+export default TodoCompleteSheet;

--- a/src/pages/todos/components/TodoDetailSheet.tsx
+++ b/src/pages/todos/components/TodoDetailSheet.tsx
@@ -8,11 +8,13 @@ import AppButton from '@/components/common/AppButton';
 import BottomSheet from '@/components/common/BottomSheet';
 import { MOCK_TODAY } from '@/mocks/mockData';
 import { PencilLine } from 'lucide-react';
+import TodoCompleteSheet from '@/pages/todos/components/TodoCompleteSheet';
 import type { ReactNode } from 'react';
 import type { TodoWithLocal } from '@/types/todo';
 import UserAvatar from '@/components/common/UserAvatar';
 import { formatDueDateLabel } from '@/utils/date';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 
 type TodoDetailSheetProps = {
   open: boolean;
@@ -52,117 +54,136 @@ const TodoDetailSheet = ({
 }: TodoDetailSheetProps) => {
   const viewState = todo ? getTodoDetailViewState(todo, myId) : null;
   const navigate = useNavigate();
+  const [completeSheetOpen, setCompleteSheetOpen] = useState(false);
+
+  const handleOpenCompleteSheet = () => {
+    setCompleteSheetOpen(true);
+    onOpenChange(false);
+  };
 
   return (
-    <BottomSheet
-      open={open}
-      onOpenChange={onOpenChange}
-      className="rounded-t-[24px] [&>div:first-child]:my-2.5 [&>div:first-child]:h-[5px] [&>div:first-child]:w-20 [&>div:first-child]:bg-zinc-400"
-    >
-      <div className="flex items-center justify-between px-5 pt-8 pb-[15px]">
-        <h2 className="text-xl font-semibold text-black">
-          {todo?.title ?? '-'}
-        </h2>
+    <>
+      <BottomSheet open={open} onOpenChange={onOpenChange}>
+        <div className="flex items-center justify-between px-5 pt-8 pb-[15px]">
+          <h2 className="text-xl font-semibold text-black">
+            {todo?.title ?? '-'}
+          </h2>
 
-        {viewState?.canEdit && (
-          <button
-            type="button"
-            onClick={() => {
-              navigate(`/todos/${todo?.id}/edit`, { state: { todo } });
-            }}
-            className="text-zinc-400"
-          >
-            <PencilLine className="h-6 w-6 transition-colors hover:text-black" />
-          </button>
-        )}
-      </div>
-
-      {/* 스크롤 영역 */}
-      <div className="min-h-0 flex-1 gap-8 overflow-y-auto p-5">
-        <div className="flex flex-col gap-6">
-          <DetailRow
-            label="마감일"
-            value={todo ? formatDueDateLabel(todo.dueAt) : '-'}
-          />
-
-          <DetailRow
-            label="담당자"
-            value={
-              <span className="inline-flex items-center gap-1">
-                <UserAvatar size="sm" src={assigneeImage} alt={assigneeName} />
-                <span>{assigneeName ?? '-'}</span>
-              </span>
-            }
-          />
-
-          <DetailRow label="반복" value="반복 없음" />
-
-          <DetailRow
-            label="메모"
-            value={
-              todo?.memo ? <span className="break-keep">{todo.memo}</span> : '-'
-            }
-            alignTop
-          />
-
-          <DetailRow
-            label="상태"
-            value={
-              <div className="flex flex-col items-end gap-1">
-                <span>{todo ? getTodoStatusLabel(todo, MOCK_TODAY) : '-'}</span>
-
-                {todo && (
-                  <span className="text-zinc-300">
-                    {getTodoStatusSubLabel(todo, MOCK_TODAY)}
-                  </span>
-                )}
-              </div>
-            }
-            alignTop
-          />
-
-          {/* 인증 사진 */}
-          {viewState?.isCompleted && todo?.proofImageUrl && (
-            <div className="flex justify-end">
-              <div className="h-37.5 w-50 rounded-[20px] bg-zinc-200" />
-            </div>
+          {viewState?.canEdit && (
+            <button
+              type="button"
+              onClick={() => {
+                navigate(`/todos/${todo?.id}/edit`, { state: { todo } });
+              }}
+              className="text-zinc-400"
+            >
+              <PencilLine className="h-6 w-6 transition-colors hover:text-black" />
+            </button>
           )}
         </div>
-      </div>
 
-      {/* 하단 버튼 */}
-      {viewState?.isMine && (
-        <div className="flex items-center justify-between gap-1 p-5">
-          <div className="flex flex-1 items-center gap-1">
-            {!viewState.isCompleted && viewState.canConfirmComplete && (
-              <AppButton className="flex-1 bg-black text-white">
-                완료하기
-              </AppButton>
+        {/* 스크롤 영역 */}
+        <div className="min-h-0 flex-1 gap-8 overflow-y-auto p-5">
+          <div className="flex flex-col gap-6">
+            <DetailRow
+              label="마감일"
+              value={todo ? formatDueDateLabel(todo.dueAt) : '-'}
+            />
+
+            <DetailRow
+              label="담당자"
+              value={
+                <span className="inline-flex items-center gap-1">
+                  <UserAvatar size="sm" src={assigneeImage} alt={assigneeName} />
+                  <span>{assigneeName ?? '-'}</span>
+                </span>
+              }
+            />
+
+            <DetailRow label="반복" value="반복 없음" />
+
+            <DetailRow
+              label="메모"
+              value={
+                todo?.memo ? (
+                  <span className="break-keep">{todo.memo}</span>
+                ) : (
+                  '-'
+                )
+              }
+              alignTop
+            />
+
+            <DetailRow
+              label="상태"
+              value={
+                <div className="flex flex-col items-end gap-1">
+                  <span>{todo ? getTodoStatusLabel(todo, MOCK_TODAY) : '-'}</span>
+
+                  {todo && (
+                    <span className="text-zinc-300">
+                      {getTodoStatusSubLabel(todo, MOCK_TODAY)}
+                    </span>
+                  )}
+                </div>
+              }
+              alignTop
+            />
+
+            {/* 인증 사진 */}
+            {viewState?.isCompleted && todo?.proofImageUrl && (
+              <div className="flex justify-end">
+                <div className="h-37.5 w-50 rounded-[20px] bg-zinc-200" />
+              </div>
             )}
-
-            {viewState.isCompleted && viewState.canRevertToInProgress && (
-              <AppButton
-                className={`flex-1 ${
-                  viewState.hasProofImage
-                    ? 'bg-black text-white'
-                    : 'border border-zinc-400'
-                }`}
-              >
-                진행 중으로 변경
-              </AppButton>
-            )}
-
-            {viewState.isCompleted &&
-              !viewState.hasProofImage &&
-              viewState.canAddProofImage && (
-                <AppButton className="flex-1 bg-black text-white">
-                  인증 사진 추가
-                </AppButton>
-              )}
           </div>
         </div>
-      )}
-    </BottomSheet>
+
+        {/* 하단 버튼 */}
+        {viewState?.isMine && (
+          <div className="flex items-center justify-between gap-1 p-5">
+            <div className="flex flex-1 items-center gap-1">
+              {!viewState.isCompleted && viewState.canConfirmComplete && (
+                <AppButton
+                  className="flex-1 bg-black text-white"
+                  onClick={handleOpenCompleteSheet}
+                >
+                  완료하기
+                </AppButton>
+              )}
+
+              {viewState.isCompleted && viewState.canRevertToInProgress && (
+                <AppButton
+                  className={`flex-1 ${
+                    viewState.hasProofImage
+                      ? 'bg-black text-white'
+                      : 'border border-zinc-400'
+                  }`}
+                >
+                  진행 중으로 변경
+                </AppButton>
+              )}
+
+              {viewState.isCompleted &&
+                !viewState.hasProofImage &&
+                viewState.canAddProofImage && (
+                  <AppButton className="flex-1 bg-black text-white">
+                    인증 사진 추가
+                  </AppButton>
+                )}
+            </div>
+          </div>
+        )}
+      </BottomSheet>
+
+      <TodoCompleteSheet
+        open={completeSheetOpen}
+        onOpenChange={setCompleteSheetOpen}
+        onConfirmComplete={() => {
+          setCompleteSheetOpen(false);
+        }}
+      />
+    </>
   );
 };
 

--- a/src/pages/todos/components/TodoDetailSheet.tsx
+++ b/src/pages/todos/components/TodoDetailSheet.tsx
@@ -167,7 +167,10 @@ const TodoDetailSheet = ({
               {viewState.isCompleted &&
                 !viewState.hasProofImage &&
                 viewState.canAddProofImage && (
-                  <AppButton className="flex-1 bg-black text-white">
+                  <AppButton
+                    className="flex-1 bg-black text-white"
+                    onClick={handleOpenCompleteSheet}
+                  >
                     인증 사진 추가
                   </AppButton>
                 )}


### PR DESCRIPTION
## PR 개요
- 할 일 완료 바텀시트를 추가하고, 사진 첨부 및 완료 플로우 개선
- 바텀 시트 스타일을 공통화하고 상태에 따른 UI 변화를 반영해 UX 개선

## 변경 사항
### 1. 할 일 완료 바텀시트 및 공통 스타일 적용
- 인증 사진 첨부 가능한 `TodoCompleteSheet` 추가
- 완료하기 클릭 시 상세 시트 → 완료 시트로 전환되는 플로우 개선
- `BottomSheet` 핸들 및 라운드 스타일 공통화, 중복 스타일 제거

### 2. 이미지 첨부 기능 및 상태 UI 반영
- 카메라/갤러리 기반 이미지 첨부 기능 구현
- 파일 형식 및 용량(최대 10MB) 검증 로직 추가
- 첨부 이미지 미리보기 및 제거 버튼 UI 적용
- 이미지 제거 시 파일/에러 상태 초기화
- 첨부 여부에 따른 버튼 텍스트 분기 (완료 하기 → 등록 하기)

### 3. 완료된 할 일과 바텀시트 연동
- 완료 상태에서 "인증 사진 추가" 클릭 시 `TodoCompleteSheet` 연결
- 바텀시트 중첩 방지를 위해 상세 시트 종료 후 완료 시트 오픈
- 완료 흐름 전반의 인터랙션 정리

## 스크린샷 (선택)
| TodoCompleteSheet |
|---|
| ![TodoCompleteSheet](https://github.com/user-attachments/assets/85529aba-4c92-42e4-a37f-82430d3476f1) |

## 추후 할 일
- #41 

## Related Issue
- Closes #40 
